### PR TITLE
fix(docker): scope npm cache per-arch to fix multi-arch build race

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,18 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# Per-architecture, locked npm cache. The CI build is multi-platform
+# (linux/amd64 + linux/arm64) and runs both arches concurrently; a cache mount
+# whose id defaults to its target is shared between them, so two parallel
+# `npm ci` runs write the same content-addressed cacache blob and collide with
+# `EEXIST: rename _cacache/tmp -> _cacache/content-v2`. Scoping the id per
+# $TARGETARCH gives each arch its own cache, and sharing=locked serializes any
+# remaining concurrent access.
+ARG TARGETARCH
+
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts
+RUN --mount=type=cache,id=npm-$TARGETARCH,target=/root/.npm,sharing=locked \
+    npm ci --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/ ./src/
@@ -17,9 +27,14 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+ARG TARGETARCH
+
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --ignore-scripts \
-    && npm cache clean --force
+# No `npm cache clean` here: /root/.npm is a cache mount, not part of the image
+# layer, so cleaning it never shrinks the image — it only wipes the shared cache
+# and adds another writer that can race the builder stage.
+RUN --mount=type=cache,id=npm-$TARGETARCH,target=/root/.npm,sharing=locked \
+    npm ci --omit=dev --ignore-scripts
 
 COPY --from=builder /app/build ./build
 


### PR DESCRIPTION
## Problem

`Publish Docker image` has failed on every recent release (v2.4.5, v2.4.6, v2.5.0) while npm publish succeeded. Root cause: the workflow builds `linux/amd64` + `linux/arm64` **concurrently**, and both Dockerfile stages used `--mount=type=cache,target=/root/.npm` whose id defaults to the target — so the cache is **shared** between the two parallel builds. Two `npm ci` processes write the same content-addressed cacache blob and collide:

```
npm error code EEXIST
npm error syscall rename
npm error path /root/.npm/_cacache/tmp/...
npm error dest /root/.npm/_cacache/content-v2/sha512/...
```

## Fix

- Scope the cache mount id per `$TARGETARCH` (`id=npm-$TARGETARCH`) and add `sharing=locked` so each arch has its own serialized cache.
- Drop `npm cache clean --force` in the release stage: `/root/.npm` is a cache mount, never part of the image layer, so cleaning it never shrank the image — it only added another writer that could race the builder stage.

## Verification

Reproduced the concurrent scenario locally with a `docker-container` builder:

```
docker buildx build --platform linux/amd64,linux/arm64 --output type=cacheonly .
```

Both arches complete `npm ci` (`id=npm-amd64` / `id=npm-arm64`) with **no EEXIST/ENOTEMPTY**. Also confirmed a native single-arch `--load` build produces a working image. Final confirmation will be the workflow run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)