### PR TITLE
feat: database views (#18) + Notion-Version 2026-03-11 — v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] — 2026-06-21
+
+### Added
+
+- **Database views.** Six new operations for Notion database views (GitHub #18): `list_views`, `get_view`, `query_view`, `create_view`, `update_view`, `delete_view`. `query_view` runs a view's stored filters/sorts and returns hydrated rows by default (set `hydrate: false` for ordered ids only), surfacing `total_count` and `truncated`; it hides Notion's create-then-paginate query mechanics. `list_views` hydrates Notion's id-only refs to `{id, name, type}` by default. `create_view` / `update_view` reuse the `where` filter shorthand and accept a raw `configuration` for type-specific layout (calendar/board/timeline/chart/map require it; a missing config is rejected locally with a fix rather than a raw API 400). `delete_view` is destructive and honors `NOTION_READ_ONLY` / the allow/block lists. See [README → Operations menu](./README.md#operations-menu-41-ops-plus-one-alias).
+
+### Changed
+
+- **Pinned `Notion-Version` bumped `2025-09-03` → `2026-03-11`.** The append-children `position` object and page/database `in_trash` field were already in use; this release also routes the legacy `update_data_source` `archived` alias into `in_trash` (the `archived` field was removed on the new surface) and adds `in_trash` to the block response schema. No dependency change (`@notionhq/client@^5.22.0`).
+
 ## [2.7.0] — 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ blocklist). Each is a comma-separated list of **tokens**, where a token is eithe
 | `blocks` | `get_block` `get_block_children` | `append_blocks` `update_block` `delete_block`† `batch_mixed_blocks`† |
 | `databases` | `query_database` | `create_database` `update_database` |
 | `data_sources` | `list_data_sources` `get_data_source` | `update_data_source` |
+| `views` | `list_views` `get_view` `query_view` | `create_view` `update_view` `delete_view`† |
 | `comments` | `list_comments` `get_comment` | `add_page_comment` `add_discussion_comment` `update_comment` `delete_comment`† |
 | `users` | `list_users` `get_user` `get_bot_user` `get_self` | — |
 | `files` | `list_file_uploads` `get_file_upload` | `upload_file` |
@@ -445,6 +446,7 @@ docker run --rm -e NOTION_TOKEN=ntn_xxx -e MCP_TRANSPORT=http -p 3000:3000 ghcr.
 - **File uploads** — `upload_file` handles single-part and multi-part (5 MB chunks) transparently; auto-detects MIME from filename; rejects `application/octet-stream`.
 - **Opt-in auto-pagination** — pass `paginate: true` on `search_pages`, `list_comments`, or `query_database` and the server walks `next_cursor` for you (capped by `page_limit`, default 10 pages ≈ 1000 items at `page_size: 100`). Other list ops return a single Notion page with `has_more` / `next_cursor`.
 - **Typed `where` filter shorthand** — `query_database` accepts a `where` clause like `{Status: {equals: "Done"}, AND: [...]}` with operator objects (`eq`, `ne`, `gte`, `lte`, `contains`, `starts_with`, etc.); the server compiles it to Notion filter JSON. Pass raw Notion `filter` JSON for edge cases the shorthand can't express (the two fields are mutually exclusive).
+- **Database views** — `list_views` / `get_view` / `query_view` plus `create_view` / `update_view` / `delete_view`. `query_view` runs a view's stored filters/sorts and returns hydrated rows by default (`hydrate: false` for ids only); `create_view` / `update_view` reuse the same `where` shorthand for filters and take a raw `configuration` for type-specific layout (calendar/board/timeline/chart/map require it).
 - **Universal MCP compatibility** — Cursor, Claude Desktop, Claude Code, Cline, Zed, Continue, anything that speaks MCP stdio.
 
 ---
@@ -506,7 +508,7 @@ Return the JSON Schema + working example for a single operation. Use this when y
 { "operation": "query_database" }
 ```
 
-### Operations menu (35 ops, plus one alias)
+### Operations menu (41 ops, plus one alias)
 
 | Area | Operations |
 | --- | --- |
@@ -514,6 +516,7 @@ Return the JSON Schema + working example for a single operation. Use this when y
 | **Blocks** | `append_blocks`, `get_block`, `get_block_children`, `update_block`, `delete_block`, `batch_mixed_blocks` |
 | **Databases** | `create_database`, `query_database`, `update_database` |
 | **Data sources** | `list_data_sources`, `get_data_source`, `update_data_source` |
+| **Views** | `list_views`, `get_view`, `query_view`, `create_view`, `update_view`, `delete_view` |
 | **Comments** | `list_comments`, `add_page_comment`, `add_discussion_comment`, `get_comment`, `update_comment`, `delete_comment` |
 | **Users** | `list_users`, `get_user`, `get_bot_user` |
 | **Files** | `upload_file`, `list_file_uploads`, `get_file_upload` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-mcp-server",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "type": "module",
   "bin": {
     "notion-mcp-server": "build/index.js"

--- a/src/operations/access.ts
+++ b/src/operations/access.ts
@@ -42,6 +42,7 @@ const DOMAIN_GROUPS: readonly OperationDomain[] = [
   "comments",
   "users",
   "files",
+  "views",
 ];
 
 /** Expand a single token to op names, or null if it matches no group and no op. */

--- a/src/operations/data-sources.ts
+++ b/src/operations/data-sources.ts
@@ -64,7 +64,7 @@ const UpdateDataSourceParams = z.object({
   title: z.array(z.unknown()).optional().describe("Rich text array for the data source title."),
   properties: z.record(z.string(), DATABASE_PROPERTY_SCHEMA).optional(),
   icon: z.unknown().optional(),
-  archived: z.boolean().optional(),
+  archived: z.boolean().optional().describe("Deprecated alias for in_trash (removed on the 2026-03-11 surface). Routed to in_trash."),
   in_trash: z.boolean().optional(),
   verbose: VERBOSE,
 });
@@ -84,13 +84,15 @@ register({
   },
   handler: tryHandler(async ({ data_source_id, title, properties, icon, archived, in_trash, verbose }) => {
     const notion = await getClient();
+    // `archived` was removed on the 2026-03-11 surface; route the legacy alias
+    // into `in_trash` so we never send a field the API rejects.
+    const trash = in_trash ?? archived;
     const body = {
       data_source_id,
       ...(title !== undefined ? { title } : {}),
       ...(properties !== undefined ? { properties } : {}),
       ...(icon !== undefined ? { icon } : {}),
-      ...(archived !== undefined ? { archived } : {}),
-      ...(in_trash !== undefined ? { in_trash } : {}),
+      ...(trash !== undefined ? { in_trash: trash } : {}),
     };
     const response = await notion.dataSources.update(asSdk<UpdateDataSourceBody>(body));
     return { ok: true, data: slimDataSource(response, verbose ?? false) };

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -12,6 +12,7 @@ export async function initOperations(): Promise<void> {
     import("./blocks.js"),
     import("./databases.js"),
     import("./data-sources.js"),
+    import("./views.js"),
     import("./comments.js"),
     import("./users.js"),
     import("./files.js"),

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -25,6 +25,12 @@ export type OperationName =
   | "list_data_sources"
   | "get_data_source"
   | "update_data_source"
+  | "list_views"
+  | "get_view"
+  | "query_view"
+  | "create_view"
+  | "update_view"
+  | "delete_view"
   | "list_comments"
   | "add_page_comment"
   | "add_discussion_comment"
@@ -48,7 +54,8 @@ export type OperationDomain =
   | "data_sources"
   | "comments"
   | "users"
-  | "files";
+  | "files"
+  | "views";
 
 export type OperationResult<T = unknown> =
   | { ok: true; data: T }

--- a/src/operations/views.ts
+++ b/src/operations/views.ts
@@ -1,0 +1,516 @@
+import { z } from "zod";
+import { isFullDatabase } from "@notionhq/client";
+import { getClient } from "../services/notion.js";
+import { register } from "./registry.js";
+import type { OperationResult } from "./types.js";
+import { tryHandler } from "../utils/handler.js";
+import { slimView, slimPage } from "../utils/slim.js";
+import { mapWithConcurrency } from "../dispatch/concurrency.js";
+import { WHERE_SCHEMA, compileWhere } from "../schema/filter-dsl.js";
+import {
+  asSdk,
+  type CreateViewBody,
+  type UpdateViewBody,
+  type CreateViewQueryBody,
+  type GetViewQueryResultsBody,
+  type DeleteViewQueryBody,
+} from "../utils/notion-types.js";
+
+const VERBOSE = z.boolean().optional();
+// Hydration fans out one pages.retrieve / views.retrieve per id. The dispatch
+// rate limiter only gates the operation as a whole, not these inner calls, so
+// keep the fan-out gentle (matches the dispatch batch default) to avoid bursting
+// past Notion's rate limit — a 429 here would surface as a hydration miss.
+const HYDRATE_CONCURRENCY = 3;
+
+const VIEW_TYPES = [
+  "table",
+  "board",
+  "list",
+  "calendar",
+  "timeline",
+  "gallery",
+  "form",
+  "chart",
+  "map",
+  "dashboard",
+] as const;
+
+// View types whose SDK config carries a required field — we require an explicit
+// `configuration` so the call fails locally with a fix instead of a raw API 400.
+const REQUIRES_CONFIG: Record<string, string> = {
+  calendar: "date_property_id (calendar views group rows by a date property)",
+  timeline: "a timeline date/range configuration",
+  board: "group_by (board views group by a property)",
+  chart: "chart axes/aggregation configuration",
+  map: "a location property configuration",
+};
+
+type ClientInstance = Awaited<ReturnType<typeof getClient>>;
+type OpError = { code: string; message: string; fix: string };
+
+// Resolve the (data_source_id, database_id) pair a view is created under.
+// Notion's createView requires BOTH in the body — the data source it targets
+// and the database it lives in — even though the SDK types database_id as
+// optional. We accept either input and look up the other.
+async function resolveViewTarget(
+  notion: ClientInstance,
+  database_id?: string,
+  data_source_id?: string
+): Promise<{ data_source_id?: string; database_id?: string; error?: OpError }> {
+  if (!database_id && !data_source_id) {
+    return {
+      error: {
+        code: "missing_target",
+        message: "Pass data_source_id or database_id.",
+        fix: "Provide data_source_id (preferred) or database_id.",
+      },
+    };
+  }
+  // data_source given without its database → look up the parent database.
+  if (data_source_id && !database_id) {
+    const ds = await notion.dataSources.retrieve({ data_source_id });
+    const parent = (ds as { parent?: { type?: string; database_id?: string } }).parent;
+    const dbId = parent?.type === "database_id" ? parent.database_id : undefined;
+    if (!dbId) {
+      return {
+        error: {
+          code: "no_parent_database",
+          message: `Could not resolve the parent database of data source ${data_source_id}.`,
+          fix: "Pass database_id explicitly alongside data_source_id.",
+        },
+      };
+    }
+    return { data_source_id, database_id: dbId };
+  }
+  // Both given → use as-is.
+  if (data_source_id && database_id) {
+    return { data_source_id, database_id };
+  }
+  // database given without a data source → resolve its single data source.
+  const db = await notion.databases.retrieve({ database_id: database_id! });
+  const sources = isFullDatabase(db) ? db.data_sources : [];
+  if (sources.length === 0) {
+    return {
+      error: {
+        code: "no_data_source",
+        message: `Database ${database_id} has no data sources.`,
+        fix: "Pass data_source_id directly, or check the database in Notion.",
+      },
+    };
+  }
+  if (sources.length > 1) {
+    return {
+      error: {
+        code: "multi_source_database",
+        message: `Database ${database_id} has ${sources.length} data sources.`,
+        fix: `Pass data_source_id. Available: ${sources.map((s) => s.id).join(", ")}.`,
+      },
+    };
+  }
+  return { data_source_id: sources[0].id, database_id };
+}
+
+// Compile the typed `where` DSL into a Notion filter, or pass `filter` through.
+function compileViewFilter(
+  where: unknown,
+  filter: unknown
+): { ok: true; filter?: unknown } | { ok: false; error: OpError } {
+  if (where !== undefined && filter !== undefined) {
+    return {
+      ok: false,
+      error: {
+        code: "filter_conflict",
+        message: "Pass `where` (typed DSL) or `filter` (raw JSON), not both.",
+        fix: "Use exactly one of `where` or `filter`.",
+      },
+    };
+  }
+  if (where !== undefined) {
+    try {
+      return { ok: true, filter: compileWhere(where as never) };
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          code: "where_compile_error",
+          message: err instanceof Error ? err.message : String(err),
+          fix: "Check the `where` clause shape, or fall back to raw `filter`.",
+        },
+      };
+    }
+  }
+  if (filter !== undefined) return { ok: true, filter };
+  return { ok: true };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// get_view
+// ──────────────────────────────────────────────────────────────────────────
+
+const GetViewParams = z.object({
+  view_id: z.string().describe("View ID to retrieve."),
+  verbose: VERBOSE,
+});
+
+register({
+  name: "get_view",
+  access: "read",
+  domain: "views",
+  description:
+    "Retrieve a single database view's configuration (name, type, filter, sorts, layout).",
+  batchable: true,
+  schema: GetViewParams,
+  example: { view_id: "<view-id>" },
+  handler: tryHandler(async ({ view_id, verbose }) => {
+    const notion = await getClient();
+    const view = await notion.views.retrieve({ view_id });
+    return { ok: true, data: slimView(view, verbose ?? false) };
+  }),
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// list_views
+// ──────────────────────────────────────────────────────────────────────────
+
+const ListViewsParams = z
+  .object({
+    database_id: z.string().optional().describe("List views under this database."),
+    data_source_id: z.string().optional().describe("List views under this data source."),
+    start_cursor: z.string().optional(),
+    page_size: z.number().min(1).max(100).optional(),
+    hydrate: z
+      .boolean()
+      .optional()
+      .describe("Fetch each view's name/type (default true). Set false for a cheap id-only list."),
+    verbose: VERBOSE,
+  })
+  .refine((v) => Boolean(v.database_id) || Boolean(v.data_source_id), {
+    message: "Pass database_id or data_source_id.",
+  });
+
+register({
+  name: "list_views",
+  access: "read",
+  domain: "views",
+  description:
+    "List views under a database or data source. Hydrates id-only refs to {id,name,type} by default.",
+  batchable: false,
+  schema: ListViewsParams,
+  example: { database_id: "<database-id>" },
+  handler: tryHandler(async ({ database_id, data_source_id, start_cursor, page_size, hydrate, verbose }) => {
+    const notion = await getClient();
+    const list = await notion.views.list({
+      ...(database_id ? { database_id } : {}),
+      ...(data_source_id ? { data_source_id } : {}),
+      ...(start_cursor ? { start_cursor } : {}),
+      ...(page_size ? { page_size } : {}),
+    });
+    const refs = (list.results ?? []) as Array<{ id: string }>;
+    const envelope = {
+      has_more: list.has_more ?? false,
+      next_cursor: list.next_cursor ?? null,
+    };
+    if (hydrate === false) {
+      return { ok: true, data: { results: refs.map((r) => ({ id: r.id })), ...envelope } };
+    }
+    const results = await mapWithConcurrency(refs, HYDRATE_CONCURRENCY, async (ref) => {
+      const view = await notion.views.retrieve({ view_id: ref.id });
+      return slimView(view, verbose ?? false);
+    });
+    return { ok: true, data: { results, ...envelope } };
+  }),
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// query_view
+// ──────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_ITEM_LIMIT = 1000;
+const MAX_ITEM_LIMIT = 1000;
+
+const QueryViewParams = z.object({
+  view_id: z.string().describe("View ID. Executes the view's stored filters/sorts server-side."),
+  page_size: z.number().min(1).max(MAX_PAGE_SIZE).optional(),
+  paginate: z.boolean().optional().describe("Walk all result pages, up to page_limit rows."),
+  page_limit: z
+    .number()
+    .min(1)
+    .max(MAX_ITEM_LIMIT)
+    .optional()
+    .describe(`Max rows when paginate:true (default ${DEFAULT_ITEM_LIMIT}).`),
+  hydrate: z
+    .boolean()
+    .optional()
+    .describe("Fetch full row data for each result (default true). Set false to return ordered ids only."),
+  verbose: VERBOSE,
+});
+
+// Loose narrow over the view-query response (create + results share this shape).
+type ViewQueryPage = {
+  id: string;
+  total_count?: number;
+  results: Array<{ id: string }>;
+  has_more?: boolean;
+  next_cursor?: string | null;
+  request_status?: { type: "complete" | "incomplete"; incomplete_reason?: string };
+};
+
+register({
+  name: "query_view",
+  access: "read",
+  domain: "views",
+  description:
+    "Query a view: runs its stored filters/sorts and returns the matching rows. Hydrates row data by default.",
+  batchable: false,
+  schema: QueryViewParams,
+  example: { view_id: "<view-id>", page_size: 50 },
+  handler: tryHandler(async ({
+    view_id,
+    page_size,
+    paginate,
+    page_limit,
+    hydrate,
+    verbose,
+  }): Promise<OperationResult<unknown>> => {
+    const notion = await getClient();
+    const pageSize = page_size ?? DEFAULT_PAGE_SIZE;
+    const doHydrate = hydrate !== false;
+
+    const hydrateIds = async (refs: Array<{ id: string }>) => {
+      if (!doHydrate) return refs.map((r) => ({ id: r.id }));
+      return mapWithConcurrency(refs, HYDRATE_CONCURRENCY, async (ref) => {
+        try {
+          const page = await notion.pages.retrieve({ page_id: ref.id });
+          return slimPage(page, verbose ?? false, true);
+        } catch {
+          // A row deleted between query and hydrate — surface the id, keep going.
+          return { id: ref.id, _hydration_failed: true };
+        }
+      });
+    };
+
+    const first = (await notion.views.queries.create(
+      asSdk<CreateViewQueryBody>({ view_id, page_size: pageSize })
+    )) as unknown as ViewQueryPage;
+    const queryId = first.id;
+    const totalCount = first.total_count;
+
+    if (!paginate) {
+      const rows = await hydrateIds(first.results ?? []);
+      const truncated = first.request_status?.type === "incomplete";
+      return {
+        ok: true,
+        data: {
+          ...(totalCount !== undefined ? { total_count: totalCount } : {}),
+          results: rows,
+          has_more: first.has_more ?? false,
+          next_cursor: first.next_cursor ?? null,
+          ...(truncated ? { truncated: true } : {}),
+        },
+      };
+    }
+
+    // paginate: accumulate refs across pages up to page_limit, then hydrate once.
+    const limit = page_limit ?? DEFAULT_ITEM_LIMIT;
+    const refs: Array<{ id: string }> = [];
+    let page: ViewQueryPage = first;
+    let pagesWalked = 1;
+    let incomplete = first.request_status?.type === "incomplete";
+    for (const r of page.results ?? []) {
+      if (refs.length >= limit) break;
+      refs.push({ id: r.id });
+    }
+    while (refs.length < limit && page.has_more && page.next_cursor) {
+      page = (await notion.views.queries.results(
+        asSdk<GetViewQueryResultsBody>({
+          view_id,
+          query_id: queryId,
+          start_cursor: page.next_cursor,
+          page_size: pageSize,
+        })
+      )) as unknown as ViewQueryPage;
+      pagesWalked += 1;
+      if (page.request_status?.type === "incomplete") incomplete = true;
+      for (const r of page.results ?? []) {
+        if (refs.length >= limit) break;
+        refs.push({ id: r.id });
+      }
+    }
+    // Best-effort cleanup of the server-side query job.
+    try {
+      await notion.views.queries.delete(
+        asSdk<DeleteViewQueryBody>({ view_id, query_id: queryId })
+      );
+    } catch {
+      /* ignore cleanup failures */
+    }
+
+    const rows = await hydrateIds(refs);
+    const truncated = incomplete || (Boolean(page.has_more) && refs.length >= limit);
+    return {
+      ok: true,
+      data: {
+        ...(totalCount !== undefined ? { total_count: totalCount } : {}),
+        results: rows,
+        truncated,
+        pages_walked: pagesWalked,
+      },
+    };
+  }),
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// create_view
+// ──────────────────────────────────────────────────────────────────────────
+
+const CreateViewParams = z.object({
+  data_source_id: z.string().optional(),
+  database_id: z
+    .string()
+    .optional()
+    .describe("Single-source databases are auto-resolved; multi-source require data_source_id."),
+  name: z.string().describe("View name."),
+  type: z.enum(VIEW_TYPES).describe("View type."),
+  where: WHERE_SCHEMA.optional().describe(
+    "Typed filter DSL (same shape as query_database `where`). Mutually exclusive with `filter`."
+  ),
+  filter: z.unknown().optional().describe("Raw Notion view filter JSON. Mutually exclusive with `where`."),
+  sorts: z.array(z.unknown()).optional(),
+  configuration: z
+    .unknown()
+    .optional()
+    .describe("Type-specific layout/grouping config (required for calendar/board/timeline/chart/map)."),
+  verbose: VERBOSE,
+});
+
+register({
+  name: "create_view",
+  access: "write",
+  domain: "views",
+  description:
+    "Create a database view. table/list/gallery/form need only name+type; calendar/board/timeline/chart/map require `configuration`.",
+  batchable: true,
+  schema: CreateViewParams,
+  example: {
+    data_source_id: "<data-source-id>",
+    name: "Open Tasks",
+    type: "table",
+    where: { Status: "Open" },
+  },
+  rollback: async (data) => {
+    const id = (data as { id?: string } | null)?.id;
+    if (!id) return;
+    const notion = await getClient();
+    try {
+      await notion.views.delete({ view_id: id });
+    } catch {
+      /* ignore */
+    }
+  },
+  handler: tryHandler(async ({ data_source_id, database_id, name, type, where, filter, sorts, configuration, verbose }) => {
+    if (REQUIRES_CONFIG[type] && configuration === undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "missing_view_config",
+          message: `A ${type} view requires \`configuration\`.`,
+          fix: `Pass \`configuration\` with ${REQUIRES_CONFIG[type]}.`,
+        },
+      };
+    }
+    // Validate inputs (filter shape) before any network call, so bad input
+    // surfaces without a round-trip and regardless of target resolution.
+    const compiled = compileViewFilter(where, filter);
+    if (!compiled.ok) return { ok: false, error: compiled.error };
+    const notion = await getClient();
+    const resolved = await resolveViewTarget(notion, database_id, data_source_id);
+    if (resolved.error) return { ok: false, error: resolved.error };
+    const body = {
+      data_source_id: resolved.data_source_id,
+      // createView requires database_id in the body (SDK types it optional, but
+      // the API rejects a body without it — confirmed against the live API).
+      database_id: resolved.database_id,
+      name,
+      type,
+      ...(compiled.filter !== undefined ? { filter: compiled.filter } : {}),
+      ...(sorts !== undefined ? { sorts } : {}),
+      ...(configuration !== undefined ? { configuration } : {}),
+    };
+    const view = await notion.views.create(asSdk<CreateViewBody>(body));
+    return { ok: true, data: slimView(view, verbose ?? false) };
+  }),
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// update_view
+// ──────────────────────────────────────────────────────────────────────────
+
+const UpdateViewParams = z.object({
+  view_id: z.string(),
+  name: z.string().optional(),
+  where: WHERE_SCHEMA.optional().describe(
+    "Replace the view filter (typed DSL). Mutually exclusive with `filter`."
+  ),
+  filter: z.unknown().optional().describe("Replace the view filter (raw JSON). Mutually exclusive with `where`."),
+  sorts: z.array(z.unknown()).optional(),
+  configuration: z.unknown().optional(),
+  clear: z
+    .array(z.enum(["filter", "sorts", "configuration"]))
+    .optional()
+    .describe("Fields to clear (set to null)."),
+  verbose: VERBOSE,
+});
+
+register({
+  name: "update_view",
+  access: "write",
+  domain: "views",
+  description:
+    "Update a view's name/filter/sorts/configuration. Use `clear` to remove filter/sorts/configuration.",
+  batchable: true,
+  schema: UpdateViewParams,
+  example: { view_id: "<view-id>", name: "Renamed" },
+  handler: tryHandler(async ({ view_id, name, where, filter, sorts, configuration, clear, verbose }) => {
+    const compiled = compileViewFilter(where, filter);
+    if (!compiled.ok) return { ok: false, error: compiled.error };
+    const toClear = new Set(clear ?? []);
+    const body: Record<string, unknown> = { view_id };
+    if (name !== undefined) body.name = name;
+    if (compiled.filter !== undefined) body.filter = compiled.filter;
+    if (sorts !== undefined) body.sorts = sorts;
+    if (configuration !== undefined) body.configuration = configuration;
+    if (toClear.has("filter")) body.filter = null;
+    if (toClear.has("sorts")) body.sorts = null;
+    if (toClear.has("configuration")) body.configuration = null;
+    const notion = await getClient();
+    const view = await notion.views.update(asSdk<UpdateViewBody>(body));
+    return { ok: true, data: slimView(view, verbose ?? false) };
+  }),
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// delete_view
+// ──────────────────────────────────────────────────────────────────────────
+
+const DeleteViewParams = z.object({ view_id: z.string() });
+
+register({
+  name: "delete_view",
+  access: "write",
+  domain: "views",
+  destructive: true,
+  description:
+    "Delete a database view. Irreversible. Honors NOTION_READ_ONLY and the operation allow/block lists.",
+  batchable: true,
+  schema: DeleteViewParams,
+  example: { view_id: "<view-id>" },
+  handler: tryHandler(async ({ view_id }) => {
+    const notion = await getClient();
+    const result = await notion.views.delete({ view_id });
+    const r = result as { id?: string; deleted?: boolean };
+    return { ok: true, data: { id: r.id ?? view_id, deleted: r.deleted ?? true } };
+  }),
+});

--- a/src/schema/blocks.ts
+++ b/src/schema/blocks.ts
@@ -22,6 +22,7 @@ export const BASE_BLOCK_REQUEST_SCHEMA = z.object({
     .optional()
     .describe("Whether block has child blocks"),
   archived: z.boolean().optional().describe("Whether block is archived"),
+  in_trash: z.boolean().optional().describe("Whether block is in trash (2026-03-11 surface)"),
 });
 
 export const TEXT_BLOCK_BASE_REQUEST_SCHEMA = z.object({

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -9,7 +9,7 @@ export async function getClient(): Promise<Client> {
   if (token !== cachedToken || cachedClient === null) {
     const fresh = new Client({
       auth: token,
-      notionVersion: "2025-09-03",
+      notionVersion: "2026-03-11",
     });
     cachedClient = fresh;
     cachedToken = token;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -193,14 +193,17 @@ function renderOperationsIndex(): string {
   for (const def of enabledOperations()) {
     lines.push(`| \`${def.name}\` | ${def.batchable ? "yes" : "no"} | ${def.description} |`);
   }
-  // Only document the query_database filter DSL when that op is actually enabled —
-  // otherwise the menu advertises a disabled operation.
-  if (!isOperationAllowed("query_database")) {
+  // Document the WHERE DSL when any operation that accepts it is enabled.
+  // query_database, create_view, and update_view all take the same `where`.
+  const whereOps = ["query_database", "create_view", "update_view"].filter((op) =>
+    isOperationAllowed(op)
+  );
+  if (whereOps.length === 0) {
     return lines.join("\n");
   }
-  lines.push("", "## `query_database` WHERE DSL", "");
+  lines.push("", "## WHERE filter DSL", "");
   lines.push(
-    "`query_database.where` is a compact DSL that compiles to the Notion filter object. AND-by-default at the top level; nest `and`/`or`/`not` (case-insensitive — `AND`/`OR`/`NOT` also work) for boolean groups, prefix scalars with `__type` to force the property type, or fall back to raw `filter` for anything the DSL can't express.",
+    `The same \`where\` DSL is accepted by ${whereOps.map((o) => `\`${o}\``).join(", ")}. It is a compact shorthand that compiles to the Notion filter object. AND-by-default at the top level; nest \`and\`/\`or\`/\`not\` (case-insensitive — \`AND\`/\`OR\`/\`NOT\` also work) for boolean groups, prefix scalars with \`__type\` to force the property type, or fall back to raw \`filter\` for anything the DSL can't express.`,
     "",
     "Common shapes:",
     "",

--- a/src/utils/notion-types.ts
+++ b/src/utils/notion-types.ts
@@ -43,6 +43,17 @@ export type UpdateCommentBody = UpdateCommentParameters;
 export type CreateFileUploadBody = CreateFileUploadParameters;
 export type SendFileUploadBody = SendFileUploadParameters;
 
+// View endpoints (2026-03-11 surface). The SDK types these via the Client
+// surface rather than top-level exports, so derive bodies from the methods.
+export type ListViewsBody = Parameters<ClientType["views"]["list"]>[0];
+export type GetViewBody = Parameters<ClientType["views"]["retrieve"]>[0];
+export type CreateViewBody = Parameters<ClientType["views"]["create"]>[0];
+export type UpdateViewBody = Parameters<ClientType["views"]["update"]>[0];
+export type DeleteViewBody = Parameters<ClientType["views"]["delete"]>[0];
+export type CreateViewQueryBody = Parameters<ClientType["views"]["queries"]["create"]>[0];
+export type GetViewQueryResultsBody = Parameters<ClientType["views"]["queries"]["results"]>[0];
+export type DeleteViewQueryBody = Parameters<ClientType["views"]["queries"]["delete"]>[0];
+
 /**
  * Cast a Zod-validated payload to its SDK request shape. The runtime value
  * has already been narrowed by the schema; this only widens the static type.

--- a/src/utils/slim.ts
+++ b/src/utils/slim.ts
@@ -245,6 +245,27 @@ export function slimDataSource(ds: DataSourceResponse, verbose = false) {
   };
 }
 
+// View objects are loosely typed on the SDK surface, so accept `unknown` and
+// narrow defensively. Default keeps the high-signal fields (id/name/type and
+// any filter/sorts); the bulky type-specific `configuration` is verbose-only.
+export function slimView(view: unknown, verbose = false) {
+  if (verbose) return view;
+  const v = (view ?? {}) as {
+    id?: string;
+    name?: string;
+    type?: string;
+    filter?: unknown;
+    sorts?: unknown;
+  };
+  return {
+    id: v.id,
+    ...(v.name !== undefined ? { name: v.name } : {}),
+    ...(v.type !== undefined ? { type: v.type } : {}),
+    ...(v.filter ? { filter: v.filter } : {}),
+    ...(Array.isArray(v.sorts) && v.sorts.length ? { sorts: v.sorts } : {}),
+  };
+}
+
 export function slimItem(
   item: SearchItemResponse,
   verbose = false,

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -357,7 +357,7 @@ describe("get_data_source", () => {
 });
 
 describe("update_data_source", () => {
-  it("forwards only the fields that were provided", async () => {
+  it("routes legacy archived to in_trash (2026-03-11 surface) and forwards only provided fields", async () => {
     notionStub.dataSources.update.mockResolvedValue({ id: "ds-1" });
 
     const res = await dispatch("update_data_source", {
@@ -367,8 +367,10 @@ describe("update_data_source", () => {
     expect((res as { ok: boolean }).ok).toBe(true);
     expect(notionStub.dataSources.update).toHaveBeenCalledWith({
       data_source_id: "ds-1",
-      archived: true,
+      in_trash: true,
     });
+    const call = notionStub.dataSources.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("archived");
   });
 });
 

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -6,11 +6,20 @@ beforeAll(async () => {
 });
 
 describe("operations registry", () => {
-  it("registers every name in the OperationName union (37 total: 35 ops + trash_page + get_self aliases)", () => {
+  it("registers every name in the OperationName union (43 total: 41 ops + trash_page + get_self aliases)", () => {
     const names = operationNames();
-    expect(names.length).toBe(37);
+    expect(names.length).toBe(43);
     expect(names).toContain("trash_page");
     expect(names).toContain("get_self");
+  });
+
+  it("includes the view ops", () => {
+    expect(getOperation("list_views")).toBeDefined();
+    expect(getOperation("get_view")).toBeDefined();
+    expect(getOperation("query_view")).toBeDefined();
+    expect(getOperation("create_view")).toBeDefined();
+    expect(getOperation("update_view")).toBeDefined();
+    expect(getOperation("delete_view")).toBeDefined();
   });
 
   it("includes the file upload ops", () => {

--- a/tests/views.test.ts
+++ b/tests/views.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+type Call = { method: string; args: unknown };
+const calls: Call[] = [];
+
+const notionStub = {
+  pages: { retrieve: vi.fn() },
+  databases: { retrieve: vi.fn() },
+  dataSources: { retrieve: vi.fn() },
+  views: {
+    list: vi.fn(),
+    retrieve: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    queries: { create: vi.fn(), results: vi.fn(), delete: vi.fn() },
+  },
+};
+
+vi.mock("../src/services/notion.js", () => ({ getClient: async () => notionStub }));
+
+import { initOperations } from "../src/operations/index.js";
+import { dispatch } from "../src/dispatch/index.js";
+
+beforeAll(async () => {
+  await initOperations();
+});
+
+beforeEach(() => {
+  calls.length = 0;
+  const resetAll = (obj: unknown): void => {
+    if (typeof obj === "function" && "mockReset" in (obj as object)) {
+      (obj as ReturnType<typeof vi.fn>).mockReset();
+      return;
+    }
+    if (obj && typeof obj === "object")
+      for (const v of Object.values(obj as Record<string, unknown>)) resetAll(v);
+  };
+  resetAll(notionStub);
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// get_view
+// ────────────────────────────────────────────────────────────────────────
+
+describe("get_view", () => {
+  it("retrieves and slims a view", async () => {
+    notionStub.views.retrieve.mockImplementation(async (args) => {
+      calls.push({ method: "views.retrieve", args });
+      return {
+        object: "view",
+        id: "v-1",
+        name: "In Progress",
+        type: "board",
+        filter: { x: 1 },
+        sorts: [],
+        configuration: { huge: "blob" },
+      };
+    });
+    const res = (await dispatch("get_view", { view_id: "v-1" })) as { ok: boolean; data: any };
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({ id: "v-1", name: "In Progress", type: "board", filter: { x: 1 } });
+    // configuration is omitted unless verbose
+    expect(res.data).not.toHaveProperty("configuration");
+    expect(calls[0]).toMatchObject({ method: "views.retrieve", args: { view_id: "v-1" } });
+  });
+
+  it("returns the full object with verbose:true", async () => {
+    notionStub.views.retrieve.mockResolvedValue({
+      object: "view",
+      id: "v-1",
+      name: "X",
+      type: "table",
+      configuration: { huge: "blob" },
+    });
+    const res = (await dispatch("get_view", { view_id: "v-1", verbose: true })) as { ok: boolean; data: any };
+    expect(res.data).toHaveProperty("configuration");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// list_views
+// ────────────────────────────────────────────────────────────────────────
+
+describe("list_views", () => {
+  it("hydrates view refs to {id,name,type} by default", async () => {
+    notionStub.views.list.mockImplementation(async (args) => {
+      calls.push({ method: "views.list", args });
+      return {
+        object: "list",
+        results: [
+          { object: "view", id: "v-1" },
+          { object: "view", id: "v-2" },
+        ],
+        has_more: false,
+        next_cursor: null,
+      };
+    });
+    notionStub.views.retrieve.mockImplementation(async ({ view_id }) => ({
+      object: "view",
+      id: view_id,
+      name: `N-${view_id}`,
+      type: "table",
+    }));
+    const res = (await dispatch("list_views", { database_id: "db-1" })) as { ok: boolean; data: any };
+    expect(res.ok).toBe(true);
+    expect(res.data.results).toEqual([
+      { id: "v-1", name: "N-v-1", type: "table" },
+      { id: "v-2", name: "N-v-2", type: "table" },
+    ]);
+    expect(calls[0]).toMatchObject({ method: "views.list", args: { database_id: "db-1" } });
+  });
+
+  it("returns raw ids when hydrate:false (no retrieve calls)", async () => {
+    notionStub.views.list.mockResolvedValue({
+      object: "list",
+      results: [{ object: "view", id: "v-9" }],
+      has_more: false,
+      next_cursor: null,
+    });
+    const res = (await dispatch("list_views", { database_id: "db-1", hydrate: false })) as {
+      ok: boolean;
+      data: any;
+    };
+    expect(res.data.results).toEqual([{ id: "v-9" }]);
+    expect(notionStub.views.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("rejects when neither database_id nor data_source_id is given", async () => {
+    const res = (await dispatch("list_views", {})) as { ok: boolean };
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// query_view
+// ────────────────────────────────────────────────────────────────────────
+
+describe("query_view", () => {
+  it("creates a query and hydrates first-page ids to rows", async () => {
+    notionStub.views.queries.create.mockImplementation(async (args) => {
+      calls.push({ method: "views.queries.create", args });
+      return {
+        object: "view_query",
+        id: "q-1",
+        view_id: "v-1",
+        total_count: 2,
+        results: [{ id: "p-1" }, { id: "p-2" }],
+        has_more: false,
+        next_cursor: null,
+      };
+    });
+    notionStub.pages.retrieve.mockImplementation(async ({ page_id }) => ({
+      object: "page",
+      id: page_id,
+      properties: { Name: { type: "title", title: [{ plain_text: `T-${page_id}` }] } },
+      url: `https://n/${page_id}`,
+      parent: { type: "database_id", database_id: "db" },
+    }));
+    const res = (await dispatch("query_view", { view_id: "v-1" })) as { ok: boolean; data: any };
+    expect(res.ok).toBe(true);
+    expect(res.data.total_count).toBe(2);
+    expect(res.data.results).toHaveLength(2);
+    expect(res.data.results[0]).toMatchObject({ id: "p-1", title: "T-p-1" });
+    expect(calls[0]).toMatchObject({ method: "views.queries.create", args: { view_id: "v-1" } });
+  });
+
+  it("returns ids only when hydrate:false (no page retrieves)", async () => {
+    notionStub.views.queries.create.mockResolvedValue({
+      object: "view_query",
+      id: "q-2",
+      view_id: "v-1",
+      total_count: 1,
+      results: [{ id: "p-9" }],
+      has_more: false,
+      next_cursor: null,
+    });
+    const res = (await dispatch("query_view", { view_id: "v-1", hydrate: false })) as {
+      ok: boolean;
+      data: any;
+    };
+    expect(res.data.results).toEqual([{ id: "p-9" }]);
+    expect(notionStub.pages.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("surfaces truncated when request_status is incomplete", async () => {
+    notionStub.views.queries.create.mockResolvedValue({
+      object: "view_query",
+      id: "q-3",
+      view_id: "v-1",
+      total_count: 5000,
+      results: [{ id: "p-1" }],
+      has_more: true,
+      next_cursor: "c1",
+      request_status: { type: "incomplete", incomplete_reason: "query_result_limit_reached" },
+    });
+    const res = (await dispatch("query_view", {
+      view_id: "v-1",
+      hydrate: false,
+      paginate: true,
+      page_limit: 1,
+    })) as { ok: boolean; data: any };
+    expect(res.data.truncated).toBe(true);
+  });
+
+  it("walks pages when paginate:true", async () => {
+    notionStub.views.queries.create.mockResolvedValue({
+      object: "view_query",
+      id: "q-4",
+      view_id: "v-1",
+      total_count: 3,
+      results: [{ id: "p-1" }],
+      has_more: true,
+      next_cursor: "c1",
+    });
+    notionStub.views.queries.results.mockResolvedValue({
+      object: "view_query",
+      id: "q-4",
+      view_id: "v-1",
+      results: [{ id: "p-2" }, { id: "p-3" }],
+      has_more: false,
+      next_cursor: null,
+    });
+    const res = (await dispatch("query_view", {
+      view_id: "v-1",
+      hydrate: false,
+      paginate: true,
+    })) as { ok: boolean; data: any };
+    expect(res.data.results).toEqual([{ id: "p-1" }, { id: "p-2" }, { id: "p-3" }]);
+    expect(res.data.pages_walked).toBe(2);
+    expect(notionStub.views.queries.delete).toHaveBeenCalled();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// create_view
+// ────────────────────────────────────────────────────────────────────────
+
+describe("create_view", () => {
+  it("creates a table view, resolving database_id from data_source_id and compiling where", async () => {
+    notionStub.dataSources.retrieve.mockResolvedValue({
+      object: "data_source",
+      id: "ds-1",
+      parent: { type: "database_id", database_id: "db-parent" },
+    });
+    notionStub.views.create.mockImplementation(async (args) => {
+      calls.push({ method: "views.create", args });
+      return { object: "view", id: "v-new", name: "Open", type: "table" };
+    });
+    const res = (await dispatch("create_view", {
+      data_source_id: "ds-1",
+      name: "Open",
+      type: "table",
+      where: { Status: "Open" },
+    })) as { ok: boolean; data: any };
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({ id: "v-new", name: "Open", type: "table" });
+    const call = calls[0].args as Record<string, unknown>;
+    // createView requires BOTH data_source_id and database_id in the body.
+    expect(call).toMatchObject({
+      data_source_id: "ds-1",
+      database_id: "db-parent",
+      name: "Open",
+      type: "table",
+    });
+    expect(call).toHaveProperty("filter");
+  });
+
+  it("rejects a calendar view without required configuration", async () => {
+    const res = (await dispatch("create_view", {
+      data_source_id: "ds-1",
+      name: "Cal",
+      type: "calendar",
+    })) as { ok: boolean; error: any };
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe("missing_view_config");
+    expect(notionStub.views.create).not.toHaveBeenCalled();
+  });
+
+  it("resolves a single-source database_id", async () => {
+    notionStub.databases.retrieve.mockResolvedValue({
+      object: "database",
+      id: "db-1",
+      data_sources: [{ id: "ds-only", name: "S" }],
+    });
+    notionStub.views.create.mockImplementation(async (args) => {
+      calls.push({ method: "views.create", args });
+      return { object: "view", id: "v-x", name: "T", type: "table" };
+    });
+    await dispatch("create_view", { database_id: "db-1", name: "T", type: "table" });
+    expect(calls[0].args as Record<string, unknown>).toMatchObject({
+      data_source_id: "ds-only",
+      database_id: "db-1",
+    });
+  });
+
+  it("rejects when both where and filter are passed", async () => {
+    const res = (await dispatch("create_view", {
+      data_source_id: "ds-1",
+      name: "X",
+      type: "table",
+      where: { Status: "Open" },
+      filter: { property: "Status", status: { equals: "Open" } },
+    })) as { ok: boolean; error: any };
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe("filter_conflict");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// update_view
+// ────────────────────────────────────────────────────────────────────────
+
+describe("update_view", () => {
+  it("updates name and compiles where", async () => {
+    notionStub.views.update.mockImplementation(async (args) => {
+      calls.push({ method: "views.update", args });
+      return { object: "view", id: "v-1", name: "Renamed", type: "table" };
+    });
+    const res = (await dispatch("update_view", {
+      view_id: "v-1",
+      name: "Renamed",
+      where: { Status: "Done" },
+    })) as { ok: boolean };
+    expect(res.ok).toBe(true);
+    const call = calls[0].args as Record<string, unknown>;
+    expect(call).toMatchObject({ view_id: "v-1", name: "Renamed" });
+    expect(call).toHaveProperty("filter");
+  });
+
+  it("clears filter when clear includes 'filter'", async () => {
+    notionStub.views.update.mockImplementation(async (args) => {
+      calls.push({ method: "views.update", args });
+      return { object: "view", id: "v-1", name: "X", type: "table" };
+    });
+    await dispatch("update_view", { view_id: "v-1", clear: ["filter"] });
+    expect((calls[0].args as Record<string, unknown>).filter).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// delete_view
+// ────────────────────────────────────────────────────────────────────────
+
+describe("delete_view", () => {
+  it("deletes a view by id", async () => {
+    notionStub.views.delete.mockImplementation(async (args) => {
+      calls.push({ method: "views.delete", args });
+      return { object: "view", id: "v-1", deleted: true };
+    });
+    const res = (await dispatch("delete_view", { view_id: "v-1" })) as { ok: boolean; data: any };
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({ id: "v-1", deleted: true });
+    expect(calls[0]).toMatchObject({ method: "views.delete", args: { view_id: "v-1" } });
+  });
+});

--- a/tests/wrapper.test.ts
+++ b/tests/wrapper.test.ts
@@ -268,7 +268,7 @@ describe("MCP wrapper: operation access gating", () => {
     expect(block.text).toContain("`get_page`");
   });
 
-  it("notion://operations drops the query_database DSL help when that op is blocked", async () => {
+  it("notion://operations keeps the WHERE DSL help when query_database is blocked but view ops still use it", async () => {
     process.env.NOTION_BLOCKED_OPERATIONS = "query_database";
     configureOperationAccess();
 
@@ -277,7 +277,22 @@ describe("MCP wrapper: operation access gating", () => {
     if (!("text" in block) || typeof block.text !== "string") {
       throw new Error("Expected text resource content");
     }
-    expect(block.text).not.toContain("WHERE DSL");
+    // query_database is gone, but create_view/update_view share the same DSL,
+    // so the help stays — now attributed to the still-enabled view ops.
     expect(block.text).not.toContain("`query_database`");
+    expect(block.text).toContain("WHERE filter DSL");
+    expect(block.text).toContain("`create_view`");
+  });
+
+  it("notion://operations drops the WHERE DSL help only when every where-op is blocked", async () => {
+    process.env.NOTION_BLOCKED_OPERATIONS = "query_database,create_view,update_view";
+    configureOperationAccess();
+
+    const res = await client.readResource({ uri: "notion://operations" });
+    const block = res.contents[0];
+    if (!("text" in block) || typeof block.text !== "string") {
+      throw new Error("Expected text resource content");
+    }
+    expect(block.text).not.toContain("WHERE filter DSL");
   });
 });


### PR DESCRIPTION
## Summary
- **Database views (closes #18):** `list_views`, `get_view`, `query_view`, `create_view`, `update_view`, `delete_view`.
- **Notion-Version bump → `2026-03-11`** (routes legacy data-source `archived` → `in_trash`; adds `in_trash` to the block schema; append `position` / page `in_trash` were already in place).

## Highlights
- `query_view` hides Notion's create-then-paginate query mechanics, hydrates rows by default (`hydrate:false` for ids-only), surfaces `total_count`/`truncated`. Bounded-parallel hydration (concurrency 3).
- `list_views` hydrates id-only refs to `{id,name,type}` by default.
- `create_view`/`update_view` reuse the `query_database` `where` DSL; raw `configuration` escape hatch with a local required-config guard (calendar/board/timeline/chart/map). The `notion://operations` WHERE-DSL help now covers all three where-ops.
- `delete_view` is destructive — honors `NOTION_READ_ONLY` + allow/block lists.

## Verification
- 267 unit tests pass; `tsc` build clean.
- **All six tools verified live** against a real workspace via a locally-installed MCP connection (create→query→update→delete round-trip + cleanup, plus `missing_view_config`/`filter_conflict` guards). Live testing caught a real bug the mocked tests missed: `create_view` requires `database_id` in the body (SDK types it optional) — fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)