### PR TITLE
chore(docker): base image to node:24-alpine (LTS) — supersedes #11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
-# Base image pinned to its multi-arch index digest (not the mutable `22-alpine`
+# Base image pinned to its multi-arch index digest (not the mutable `24-alpine`
 # tag) so the registry can't swap the contents under us. Dependabot's docker
 # ecosystem bumps this digest in a reviewed PR. Resolve a new one with:
-#   docker buildx imagetools inspect node:22-alpine
-FROM node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd AS builder
+#   docker buildx imagetools inspect node:24-alpine
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-FROM node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd AS release
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS release
 
 WORKDIR /app
 


### PR DESCRIPTION
Dependabot #11 proposed bumping the base image to **node:26-alpine**, but Node 26 is **not LTS** (`v26.3.1`, `LTS:false`) — not appropriate for a published runtime image. This moves to the current **Active LTS** instead: **Node 24 ('Krypton')**, digest-pinned to its multi-arch index.

Verified locally: image builds and the release stage boots the v2.8.0 server (43/43 ops). Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)