### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.0] — 2026-06-21
 
 ### Added
 
-- **HTTP(S) proxy support.** The Notion client now routes its requests through an HTTP(S) proxy when one is configured via the standard `HTTPS_PROXY` / `HTTP_PROXY` (and lowercase) environment variables; with no proxy set, behavior is unchanged. Useful behind corporate proxies. (Thanks @KokomiSensei — original PR #17, rebased onto v2.8.0.)
+- **HTTP(S) proxy support.** The Notion client now routes its requests through an HTTP(S) proxy when one is configured via the standard `HTTPS_PROXY` / `HTTP_PROXY` (and lowercase) environment variables; with no proxy set, behavior is unchanged. Useful behind corporate proxies. (Thanks @KokomiSensei — original PR #17.)
+
+### Changed
+
+- **Docker base image → `node:24-alpine`** (current Active LTS, digest-pinned), up from `node:22-alpine`. Dependabot proposed the non-LTS `node:26`; we stay on LTS.
+- **Dev toolchain bumps:** TypeScript `5.9 → 6.0`, `@types/node` `22 → 25`, `shx` `0.3 → 0.4`, `vitest` `4.1.7 → 4.1.8`, and pinned GitHub Actions SHAs refreshed. No runtime impact.
 
 ## [2.8.0] — 2026-06-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-mcp-server",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "type": "module",
   "bin": {
     "notion-mcp-server": "build/index.js"


### PR DESCRIPTION
Release v2.9.0.

- **Added:** HTTP(S) proxy support (`HTTPS_PROXY`/`HTTP_PROXY`) — thanks @KokomiSensei.
- **Changed:** Docker base → `node:24-alpine` (LTS); dev toolchain bumps (TypeScript 6, @types/node 25, shx 0.4, vitest 4.1.8, Actions SHAs).

`npm ci` clean (0 vulns), build clean, 267 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)