### PR TITLE
feat: create pages from Notion templates + list_data_source_templates

### DIFF
--- a/src/operations/data-sources.ts
+++ b/src/operations/data-sources.ts
@@ -59,6 +59,36 @@ register({
   }),
 });
 
+const ListDataSourceTemplatesParams = z.object({
+  data_source_id: z.string().describe("Data source ID to list templates for."),
+  name: z.string().optional().describe("Case-insensitive substring filter on template name."),
+  start_cursor: z.string().optional(),
+  page_size: z.number().int().min(1).max(100).optional(),
+});
+
+register({
+  name: "list_data_source_templates",
+  access: "read",
+  domain: "data_sources",
+  description: "List the page templates available for a data source. Returns {id, name, is_default} per template. Pass a returned id as template.template_id to create_page to apply it.",
+  batchable: false,
+  schema: ListDataSourceTemplatesParams,
+  example: { data_source_id: "<data-source-id>" },
+  handler: tryHandler(async ({ data_source_id, name, start_cursor, page_size }) => {
+    const notion = await getClient();
+    const res = await notion.dataSources.listTemplates({
+      data_source_id,
+      ...(name !== undefined ? { name } : {}),
+      ...(start_cursor !== undefined ? { start_cursor } : {}),
+      ...(page_size !== undefined ? { page_size } : {}),
+    });
+    return {
+      ok: true,
+      data: { data_source_id, templates: res.templates },
+    };
+  }),
+});
+
 const UpdateDataSourceParams = z.object({
   data_source_id: z.string(),
   title: z.array(z.unknown()).optional().describe("Rich text array for the data source title."),

--- a/src/operations/pages.ts
+++ b/src/operations/pages.ts
@@ -75,12 +75,26 @@ const CreatePageParams = z
     properties: z.record(z.string(), PROPERTY_VALUE_SCHEMA).optional(),
     markdown: z.string().optional().describe("Page body as markdown. Parsed server-side."),
     children: z.array(z.unknown()).optional().describe("Structured Notion blocks. Mutually exclusive with markdown."),
+    template: z
+      .object({
+        type: z.enum(["default", "none", "template_id"]).describe("`template_id` to apply a specific template, `default` for the data source's default template, `none` for no template."),
+        template_id: z.string().optional().describe("Required when type is 'template_id'. Discover IDs via list_data_source_templates."),
+        timezone: z.string().optional().describe("IANA tz (e.g. 'Asia/Hong_Kong') controlling @now/@today resolution inside the template."),
+      })
+      .optional()
+      .describe("Create the page from a Notion template. The API forbids `markdown`/`children` alongside a template; only data_source_id parents support templates."),
     icon: ICON_SCHEMA.nullable().optional(),
     cover: FILE_SCHEMA.nullable().optional(),
     verbose: VERBOSE,
   })
   .refine((v) => !(v.markdown && v.children), {
     message: "Pass either `markdown` or `children`, not both.",
+  })
+  .refine((v) => !(v.template && (v.markdown || v.children)), {
+    message: "Pass either a `template` or body content (`markdown`/`children`), not both — the Notion API rejects children alongside a template.",
+  })
+  .refine((v) => !(v.template?.type === "template_id" && !v.template.template_id), {
+    message: "template.template_id is required when template.type is 'template_id'.",
   });
 
 register({
@@ -127,15 +141,19 @@ register({
         title: [{ type: "text", text: { content: params.title } }],
       };
     }
-    const children = params.markdown
-      ? parseMarkdownToBlocks(params.markdown)
-      : params.children;
+    // A template and explicit body content are mutually exclusive (API rule).
+    const children = params.template
+      ? undefined
+      : params.markdown
+        ? parseMarkdownToBlocks(params.markdown)
+        : params.children;
 
     const notion = await getClient();
     const body = {
       parent,
       properties,
       ...(children && children.length ? { children } : {}),
+      ...(params.template ? { template: params.template } : {}),
       ...(params.icon !== undefined ? { icon: params.icon } : {}),
       ...(params.cover !== undefined ? { cover: params.cover } : {}),
     };

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -25,6 +25,7 @@ export type OperationName =
   | "list_data_sources"
   | "get_data_source"
   | "update_data_source"
+  | "list_data_source_templates"
   | "list_views"
   | "get_view"
   | "query_view"

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -6,9 +6,9 @@ beforeAll(async () => {
 });
 
 describe("operations registry", () => {
-  it("registers every name in the OperationName union (43 total: 41 ops + trash_page + get_self aliases)", () => {
+  it("registers every name in the OperationName union (44 total: 42 ops + trash_page + get_self aliases)", () => {
     const names = operationNames();
-    expect(names.length).toBe(43);
+    expect(names.length).toBe(44);
     expect(names).toContain("trash_page");
     expect(names).toContain("get_self");
   });


### PR DESCRIPTION
## Summary

`create_page` could not apply a Notion template, and there was no way to discover the templates a data source has. Notion added template support to the public API (applying a template on create landed with API version `2025-09-03`, listing templates with `2026-03-11`), and the pinned `@notionhq/client` v5 SDK already types both: `template` on `CreatePageParameters` and a `dataSources.listTemplates()` method. This PR exposes them through the operation registry.

Two changes:

1. `create_page` gains an optional `template` field, `{ type: "template_id" | "default" | "none", template_id?, timezone? }`, passed straight through to `pages.create`. It is mutually exclusive with `markdown`/`children` (the API rejects body content alongside a template) and requires `template_id` when `type` is `"template_id"`. Both rules are enforced with `refine`s that return a clear message.
2. A new read operation, `list_data_source_templates`, wraps `dataSources.listTemplates` and returns `{ id, name, is_default }` per template, so a caller can find the `template_id` to apply.

No new dependencies, and no version bump needed: the server already pins `notionVersion: 2026-03-11`, which covers both endpoints.

## Linked issue

No issue. The README's Contributing section documents a fork to branch to PR flow with no issue step, so I followed that. Happy to open a tracking issue first if you would prefer.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

With a `NOTION_TOKEN` whose integration can see a database that has templates:

1. List the templates for a data source:
   `notion_execute({ operation: "list_data_source_templates", payload: { data_source_id: "<ds-id>" } })`
   returns `{ templates: [{ id, name, is_default }, ...] }`.
2. Create a page from a specific template:
   `notion_execute({ operation: "create_page", payload: { parent: { type: "data_source_id", data_source_id: "<ds-id>" }, title: "From template", template: { type: "template_id", template_id: "<id from step 1>" } } })`.
3. Or use the data source's default template with `template: { type: "default" }`.
4. Confirm the guard rails: passing both `template` and `markdown` is rejected, and `template: { type: "template_id" }` without a `template_id` is rejected, each with a descriptive message.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end (listed templates, created a page from a named template and from the default template, against a real workspace; both guard-rail errors fire as expected). `npm run build`, `npm test` (267 passing), and `npm audit --omit=dev --audit-level=high` (0 vulnerabilities) all pass locally.

## Model used

Claude Opus 4.8 via Claude Code. It drafted the implementation and this description; a human directed the approach and reviewed the diff.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @Omee11
