### PR TITLE
fix(schema): use data_source_id for relation targets

### DIFF
--- a/src/schema/database.ts
+++ b/src/schema/database.ts
@@ -160,9 +160,9 @@ export const RELATION_DB_PROPERTY_SCHEMA = z.object({
   type: z.literal("relation").describe("Relation property type"),
   relation: z
     .object({
-      database_id: z
+      data_source_id: z
         .string()
-        .describe("The ID of the database this relation refers to"),
+        .describe("The ID of the data source this relation refers to"),
       synced_property_name: z
         .string()
         .optional()

--- a/tests/database-schema.test.ts
+++ b/tests/database-schema.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { emitJsonSchema } from "../src/schema/emit.js";
+import { RELATION_DB_PROPERTY_SCHEMA } from "../src/schema/database.js";
+
+describe("relation database property schema", () => {
+  it("accepts a data-source relation target", () => {
+    const value = {
+      type: "relation" as const,
+      relation: {
+        data_source_id: "data-source-id",
+        single_property: {},
+      },
+    };
+
+    expect(RELATION_DB_PROPERTY_SCHEMA.parse(value)).toEqual(value);
+  });
+
+  it("emits data_source_id instead of the legacy database_id", () => {
+    const json = emitJsonSchema(RELATION_DB_PROPERTY_SCHEMA) as any;
+    const relation = json.properties.relation;
+
+    expect(relation.properties.data_source_id).toMatchObject({ type: "string" });
+    expect(relation.properties.database_id).toBeUndefined();
+    expect(relation.required).toContain("data_source_id");
+  });
+});


### PR DESCRIPTION
## Summary

- use `data_source_id` for relation-property targets
- align the emitted MCP schema with the pinned Notion SDK/API surface
- add regression tests for parsing and JSON Schema emission

## Problem

`RELATION_DB_PROPERTY_SCHEMA` currently requires `relation.database_id`. The server's pinned Notion SDK defines relation-property requests with `relation.data_source_id` for both initial database data-source properties and data-source schema updates.

This causes valid `update_data_source` and relation-bearing `create_database` payloads to fail wrapper validation before they reach Notion. Supplying `database_id` satisfies the wrapper but is rejected by the current Notion endpoint.

## Change

Replace the stale `database_id` field with `data_source_id` and update its description. The new tests verify that the schema accepts the current request shape and emits `data_source_id` rather than `database_id`.

## Verification

- `npm run test` — 24 test files, 269 tests passed
- `npm run build` — passed
