### PR TITLE
feat(registry): publish to the official MCP registry on release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -52,6 +52,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          # The io.modelcontextprotocol.server.name label lets the official MCP
+          # registry verify image ownership if we later add an OCI package to
+          # server.json.
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.modelcontextprotocol.server.name=io.github.awkoy/notion-mcp-server
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,3 +50,31 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
+
+      - name: Sync server.json version with package.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const { version } = require('./package.json');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = version;
+            for (const p of s.packages) p.version = version;
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Publish to MCP Registry
+        # Retries because the registry validates the mcpName field against the
+        # package.json served by registry.npmjs.org, and the version published
+        # above can take a minute to propagate.
+        run: |
+          ./mcp-publisher login github-oidc
+          for i in 1 2 3 4 5; do
+            ./mcp-publisher publish && exit 0
+            echo "Publish attempt $i failed, retrying in 60s..."
+            sleep 60
+          done
+          exit 1

--- a/README.md
+++ b/README.md
@@ -533,3 +533,7 @@ PRs welcome. Fork → branch → commit → push → PR. Run `npm test` before s
 ## 📄 License
 
 MIT — see [LICENSE](./LICENSE).
+
+---
+
+mcp-name: io.github.awkoy/notion-mcp-server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "notion-mcp-server",
   "version": "2.10.0",
+  "mcpName": "io.github.awkoy/notion-mcp-server",
   "type": "module",
   "bin": {
     "notion-mcp-server": "build/index.js"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.awkoy/notion-mcp-server",
+  "description": "Token-auth Notion MCP: pages, databases, blocks, comments, files. Runs headless in CI and agents.",
+  "repository": {
+    "url": "https://github.com/awkoy/notion-mcp-server",
+    "source": "github"
+  },
+  "version": "2.10.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "notion-mcp-server",
+      "version": "2.10.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "NOTION_TOKEN",
+          "description": "Notion Personal Access Token (ntn_...) or Internal Integration Secret. Create at https://app.notion.com/developers/tokens",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "NOTION_PAGE_ID",
+          "description": "Optional default parent page ID used by create_page / create_database when no parent is passed.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Gets `notion-mcp-server` into the official MCP registry (registry.modelcontextprotocol.io) — currently we're absent while competitors (e.g. `io.github.n24q02m/better-notion-mcp`) are listed. The registry feeds server discovery in a growing number of MCP clients.

## Changes

- **`server.json`** — registry manifest (`io.github.awkoy/notion-mcp-server`), npm package with stdio transport, `NOTION_TOKEN` / `NOTION_PAGE_ID` env vars. Validated against the 2025-12-11 schema.
- **`package.json`** — `mcpName` field; the registry validates npm package ownership by fetching the published package.json and checking this field, so the first registry publish must ride the same release that ships this field (it will — same workflow).
- **`publish-npm.yml`** — after `npm publish`: sync `server.json` version from package.json, install `mcp-publisher`, login via GitHub OIDC (grants the `io.github.awkoy/*` namespace; `id-token: write` was already set), publish with retries to absorb npm propagation delay.
- **`publish-docker.yml`** — adds the `io.modelcontextprotocol.server.name` OCI label so a future release can add the GHCR image to `server.json` as an OCI package (registry verifies image ownership via this label).
- **README** — `mcp-name` marker line.

## Verification

- `server.json` validated against the official JSON schema locally
- Both workflows YAML-parse
- `npm test`: 267/267 pass

First actual registry publish happens on the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)