### PR TITLE
feat(mcpb): Claude Desktop one-click extension bundle

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,41 @@
+name: Publish Claude Desktop extension (.mcpb)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release / upload the asset
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        # Same supply-chain posture as publish-npm.yml: no lifecycle scripts.
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack .mcpb
+        run: node scripts/build-mcpb.mjs
+
+      - name: Attach to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release upload "$TAG" dist/notion-mcp-server.mcpb --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .cursorconfig
 .cursorignorerules
 .cursorignoreconfig
+/mcpb/stage

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ VS Code prompts for the token on install and stores it as a secret input.
 
 ### Claude Desktop
 
-Settings → Developer → Edit Config, then add:
+**Easiest: the one-click extension.** Download [`notion-mcp-server.mcpb` from the latest release](https://github.com/awkoy/notion-mcp-server/releases/latest/download/notion-mcp-server.mcpb), double-click it (or drag into Claude Desktop → Settings → Extensions), paste your Notion token when prompted — done. No config files, Node.js not required.
+
+**Or via the config file:** Settings → Developer → Edit Config, then add:
 
 ```json
 {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,56 @@
+{
+  "manifest_version": "0.2",
+  "name": "notion-mcp-server",
+  "display_name": "Notion MCP Server",
+  "version": "0.0.0",
+  "description": "Connect Claude to Notion: create pages, query databases, append blocks, comment, and upload files.",
+  "long_description": "Token-auth Notion MCP server. 43 operations behind 2 context-efficient tools: pages, databases, blocks, comments, users, files, and templates — with batched mutations, automatic retry on rate limits, and full markdown round-trip. Paste a Notion Personal Access Token (create one at https://app.notion.com/developers/tokens) and everything you can see in Notion, Claude can work with.",
+  "author": {
+    "name": "Yaroslav Boiko",
+    "email": "y.boikodeveloper@gmail.com",
+    "url": "https://github.com/awkoy"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/awkoy/notion-mcp-server"
+  },
+  "homepage": "https://github.com/awkoy/notion-mcp-server",
+  "documentation": "https://github.com/awkoy/notion-mcp-server#readme",
+  "license": "MIT",
+  "keywords": ["notion", "notion-api", "productivity", "pages", "databases", "markdown"],
+  "server": {
+    "type": "node",
+    "entry_point": "build/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/build/index.js"],
+      "env": {
+        "NOTION_TOKEN": "${user_config.notion_token}",
+        "NOTION_PAGE_ID": "${user_config.notion_page_id}"
+      }
+    }
+  },
+  "user_config": {
+    "notion_token": {
+      "type": "string",
+      "title": "Notion token",
+      "description": "Personal Access Token (ntn_...) or Internal Integration Secret. Create one at https://app.notion.com/developers/tokens — a PAT sees everything you can see, no per-page sharing needed.",
+      "sensitive": true,
+      "required": true
+    },
+    "notion_page_id": {
+      "type": "string",
+      "title": "Default parent page ID (optional)",
+      "description": "Used by create_page / create_database when no parent is specified. Leave empty to always pass a parent explicitly.",
+      "sensitive": false,
+      "required": false,
+      "default": ""
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=20"
+    }
+  }
+}

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Builds the Claude Desktop extension bundle (.mcpb).
+//
+// Stages a minimal package (manifest + compiled server + production deps)
+// under mcpb/stage/ and packs it with @anthropic-ai/mcpb. Output lands in
+// dist/notion-mcp-server.mcpb.
+//
+// Prerequisites: `npm run build` has produced build/.
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const stage = path.join(root, "mcpb", "stage");
+const dist = path.join(root, "dist");
+
+const run = (cmd, cwd = root) => execSync(cmd, { cwd, stdio: "inherit" });
+
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+if (!fs.existsSync(path.join(root, "build", "index.js"))) {
+  console.error("build/index.js missing — run `npm run build` first.");
+  process.exit(1);
+}
+
+fs.rmSync(stage, { recursive: true, force: true });
+fs.mkdirSync(stage, { recursive: true });
+fs.mkdirSync(dist, { recursive: true });
+
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(root, "mcpb", "manifest.json"), "utf8")
+);
+manifest.version = pkg.version;
+fs.writeFileSync(
+  path.join(stage, "manifest.json"),
+  JSON.stringify(manifest, null, 2) + "\n"
+);
+
+fs.cpSync(path.join(root, "build"), path.join(stage, "build"), {
+  recursive: true,
+});
+for (const f of ["package.json", "package-lock.json", "LICENSE"]) {
+  fs.copyFileSync(path.join(root, f), path.join(stage, f));
+}
+
+// Production deps only; --ignore-scripts for the same supply-chain reasons
+// as publish-npm.yml (no runtime dep needs a lifecycle script).
+run("npm install --omit=dev --ignore-scripts --no-audit --no-fund", stage);
+
+run(`npx -y @anthropic-ai/mcpb validate ${path.join(stage, "manifest.json")}`);
+run(
+  `npx -y @anthropic-ai/mcpb pack ${stage} ${path.join(dist, "notion-mcp-server.mcpb")}`
+);
+
+console.log(`\nPacked dist/notion-mcp-server.mcpb (v${pkg.version})`);


### PR DESCRIPTION
## What

Ships a `.mcpb` (Claude Desktop extension) with every release — one-click install for non-developers: download, double-click, paste token. No config-file editing, no Node.js required on the user's machine.

## Changes

- **`mcpb/manifest.json`** — MCPB manifest (`manifest_version: 0.2`), `user_config` prompts for `NOTION_TOKEN` (sensitive, required) and optional `NOTION_PAGE_ID` (empty string is falsy in `resolveParent`, so leaving it blank is safe).
- **`scripts/build-mcpb.mjs`** — stages manifest (version synced from package.json) + `build/` + production-only deps (`--ignore-scripts`, same posture as publish-npm.yml), then `mcpb validate` + `mcpb pack` → `dist/notion-mcp-server.mcpb` (~4.5 MB).
- **`.github/workflows/publish-mcpb.yml`** — on `v*` tag: build, pack, attach to the GitHub release (creates it with generated notes if it doesn't exist).
- **README** — one-click install path in the Claude Desktop section.

## Verification

- `mcpb validate` passes; packed locally with mcpb CLI 2.1.2
- Staged bundle smoke-tested: responds to MCP `initialize` over stdio
- `npm test`: 267/267 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)