### PR TITLE
chore(release): v2.10.1 — MCP registry + Claude Desktop extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.1] — 2026-07-03
+
+Distribution release — no runtime changes to the server itself.
+
+### Added
+
+- **Official MCP registry.** The server is published to [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) as `io.github.awkoy/notion-mcp-server`: `server.json` manifest, `mcpName` field in package.json, and automatic registry publish (GitHub OIDC) in the npm release workflow. (#29)
+- **Claude Desktop one-click extension.** Every release now attaches `notion-mcp-server.mcpb` — download, double-click, paste your Notion token; no config-file editing or Node.js required. (#30)
+- **OCI registry label.** Docker images now carry `io.modelcontextprotocol.server.name`, allowing the GHCR image to be added to the MCP registry entry later. (#29)
+
 ## [2.10.0] — 2026-07-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-mcp-server",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "mcpName": "io.github.awkoy/notion-mcp-server",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/awkoy/notion-mcp-server",
     "source": "github"
   },
-  "version": "2.10.0",
+  "version": "2.10.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "notion-mcp-server",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump + changelog for the distribution release.

**Merge order: merge #30 (mcpb bundle) first, then this PR, then tag.** The changelog references both #29 (already merged) and #30.

On `git tag v2.10.1 && git push origin v2.10.1` the release automation will:
1. Publish `notion-mcp-server@2.10.1` to npm (with the new `mcpName` field)
2. Publish `io.github.awkoy/notion-mcp-server` to the official MCP registry — first time we appear there
3. Push the Docker image (now with the MCP OCI label)
4. Build and attach `notion-mcp-server.mcpb` to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)