### PR TITLE
chore(release): v2.11.0 — data_source_id for relation targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] — 2026-07-03
+
+### Fixed
+
+- **Relation properties now target a data source, not a database.** When defining a `relation` database property, the field is now `data_source_id` (was `database_id`), matching Notion's data-source model under the pinned `Notion-Version: 2026-03-11` — the old field was rejected by the API. If you were passing `database_id` inside a relation config, switch to `data_source_id` (resolve it with `list_data_sources` if needed). (Thanks @insane66613 — PR #28.)
+
 ## [2.10.1] — 2026-07-03
 
 Distribution release — no runtime changes to the server itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-mcp-server",
-      "version": "2.10.1",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-mcp-server",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "mcpName": "io.github.awkoy/notion-mcp-server",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/awkoy/notion-mcp-server",
     "source": "github"
   },
-  "version": "2.10.1",
+  "version": "2.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "notion-mcp-server",
-      "version": "2.10.1",
+      "version": "2.11.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump + changelog for v2.11.0.

Ships #28 (thanks @insane66613): relation database properties now use `data_source_id` instead of `database_id`, matching Notion's data-source model under the pinned `Notion-Version: 2026-03-11`. Minor bump (not patch) because it changes a user-facing field name.

On tag `v2.11.0`, the release automation publishes npm + official MCP registry, pushes the Docker image, and attaches the `.mcpb` to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)