### PR TITLE
feat(files): local path source + markdown/office MIME inference

### DIFF
--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,93 @@
+# Running this fork (local changes)
+
+This fork adds a **`path` source** to `upload_file` so the server reads local
+files directly from disk instead of receiving them as base64 through the tool
+call. See [PR #38](https://github.com/awkoy/notion-mcp-server/pull/38). Because
+the change isn't on npm, you run the server from source instead of
+`npx -y notion-mcp-server`.
+
+Pick one of the setups below.
+
+## Option A — local clone (recommended)
+
+Fastest startup and easiest to update. Build once, point your client at the
+compiled entrypoint.
+
+```bash
+git clone -b feat/local-path-source https://github.com/qch2012/notion-mcp-server.git
+cd notion-mcp-server
+npm install
+npm run build      # compiles to build/index.js
+```
+
+Then configure the client to launch that build directly. For Claude Code
+(`~/.claude.json`) or Claude Desktop (`claude_desktop_config.json`):
+
+```jsonc
+"notion": {
+  "type": "stdio",
+  "command": "node",
+  "args": ["/absolute/path/to/notion-mcp-server/build/index.js"],
+  "env": {
+    "NOTION_TOKEN": "ntn_your_token",
+    "NOTION_RATE_LIMIT": "5"
+  }
+}
+```
+
+Reconnect the MCP server (in Claude Code: `/mcp reconnect`).
+
+**To update:** `git pull && npm run build`, then reconnect.
+
+## Option B — `npx` straight from the fork
+
+No local checkout to maintain — npm clones the branch and runs the `prepare`
+script (which builds) on install.
+
+```jsonc
+"notion": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "github:qch2012/notion-mcp-server#feat/local-path-source"],
+  "env": {
+    "NOTION_TOKEN": "ntn_your_token",
+    "NOTION_RATE_LIMIT": "5"
+  }
+}
+```
+
+Trade-offs: slower first launch (clone + install devDeps + `tsc`), and `npx`
+caches aggressively — after new commits are pushed to the branch, clear the
+cache to pick them up:
+
+```bash
+rm -rf ~/.npm/_npx      # or: npx clear-npx-cache
+```
+
+## Using the new `path` source
+
+Once running, upload local files without base64 — the server reads the bytes
+itself, so nothing routes through the model:
+
+```jsonc
+// minimal: filename derived from basename, content_type inferred from extension
+{ "operation": "upload_file",
+  "payload": { "source": { "type": "path", "path": "~/docs/spec.pdf" } } }
+```
+
+- `~` and `~/` expand to your home directory.
+- `filename` is optional for a `path` source (defaults to the basename); it
+  stays required for `base64`/`url`.
+- `content_type` is inferred from the extension. The allowlist includes
+  Markdown (`.md`) and Office formats (`.docx`, `.pptx`, `.xlsx`, …); pass
+  `content_type` explicitly for anything outside it.
+- Files over ~5 MB: pass `"mode": "multi"` for chunked multi-part upload.
+
+The existing `base64` and `url` sources are unchanged.
+
+## Notes
+
+- `NOTION_RATE_LIMIT` (default `3`) sets request pacing; `5` speeds up bursts
+  of calls, with the built-in backoff absorbing the occasional 429.
+- Once PR #38 merges upstream and a release ships, you can switch back to
+  `npx -y notion-mcp-server`.

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -20,8 +20,22 @@ npm install
 npm run build      # compiles to build/index.js
 ```
 
-Then configure the client to launch that build directly. For Claude Code
-(`~/.claude.json`) or Claude Desktop (`claude_desktop_config.json`):
+Then register it with Claude Code — the `claude mcp add` CLI writes the entry
+into `~/.claude.json` for you (everything after `--` is how to launch the
+server):
+
+```bash
+claude mcp add notion -s user \
+  -e NOTION_TOKEN=ntn_your_token \
+  -e NOTION_RATE_LIMIT=5 \
+  -- node /absolute/path/to/notion-mcp-server/build/index.js
+```
+
+If a `notion` entry already exists, remove it first:
+`claude mcp remove notion -s user`.
+
+Or edit the config file by hand (Claude Code `~/.claude.json`, Claude Desktop
+`claude_desktop_config.json`):
 
 ```jsonc
 "notion": {
@@ -43,6 +57,15 @@ Reconnect the MCP server (in Claude Code: `/mcp reconnect`).
 
 No local checkout to maintain — npm clones the branch and runs the `prepare`
 script (which builds) on install.
+
+```bash
+claude mcp add notion -s user \
+  -e NOTION_TOKEN=ntn_your_token \
+  -e NOTION_RATE_LIMIT=5 \
+  -- npx -y github:qch2012/notion-mcp-server#feat/local-path-source
+```
+
+Or by hand:
 
 ```jsonc
 "notion": {

--- a/src/operations/files.ts
+++ b/src/operations/files.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename } from "node:path";
 import { getClient } from "../services/notion.js";
 import { register } from "./registry.js";
 import { tryHandler } from "../utils/handler.js";
@@ -24,9 +27,26 @@ const SourceSchema = z.discriminatedUnion("type", [
     type: z.literal("url"),
     url: z.url().describe("Public URL to fetch the file bytes from."),
   }),
+  z.object({
+    type: z.literal("path"),
+    path: z
+      .string()
+      .describe(
+        "Local filesystem path (absolute, or ~-relative). The server reads the file directly — bytes never pass through the tool call, so this is the fastest, cheapest source for files on the same machine as the server."
+      ),
+  }),
 ]);
 
 type Source = z.infer<typeof SourceSchema>;
+
+// Expand a leading ~ or ~/ to the current user's home directory. Node's fs
+// does not do this itself, and ~-relative paths are the common shape a caller
+// hands to a local stdio server.
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return homedir() + p.slice(1);
+  return p;
+}
 
 // Returns Uint8Array<ArrayBuffer> — the DOM Blob constructor's BlobPart type
 // rejects Uint8Array<ArrayBufferLike> under newer @types/node (it widens to
@@ -34,6 +54,12 @@ type Source = z.infer<typeof SourceSchema>;
 async function resolveBytes(source: Source): Promise<Uint8Array<ArrayBuffer>> {
   if (source.type === "base64") {
     const buf = Buffer.from(source.data, "base64");
+    const out = new Uint8Array(buf.byteLength);
+    out.set(buf);
+    return out;
+  }
+  if (source.type === "path") {
+    const buf = await readFile(expandHome(source.path));
     const out = new Uint8Array(buf.byteLength);
     out.set(buf);
     return out;
@@ -115,8 +141,17 @@ const EXTENSION_TO_MIME: Record<string, string> = {
   // Documents
   csv: "text/csv",
   json: "application/json",
+  md: "text/markdown",
+  markdown: "text/markdown",
   pdf: "application/pdf",
   txt: "text/plain",
+  // Microsoft Office
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 };
 
 function inferContentType(filename: string): string | undefined {
@@ -135,7 +170,12 @@ const UploadFileParams = z.object({
     .enum(["single", "multi"])
     .optional()
     .describe("'single' (default) = one create+send call. 'multi' = chunk into 5MB parts then complete."),
-  filename: z.string(),
+  filename: z
+    .string()
+    .optional()
+    .describe(
+      "Required for base64 and url sources. Optional for a path source — defaults to the file's basename."
+    ),
   content_type: z.string().optional(),
   source: SourceSchema,
 });
@@ -145,7 +185,7 @@ register({
   access: "write",
   domain: "files",
   description:
-    "Upload a file via Notion's file_uploads API. Handles single-part (one create + one send) and multi-part (create + N sends + complete) transparently.\n\nSource shapes:\n  • Base64 bytes: `source: { type: \"base64\", data: \"<b64 string>\" }`\n  • Public URL:   `source: { type: \"url\", url: \"https://example.com/file.pdf\" }` (the server fetches it server-side).\n\n`mode` defaults to \"single\"; only pass \"multi\" for files larger than ~5MB.",
+    "Upload a file via Notion's file_uploads API. Handles single-part (one create + one send) and multi-part (create + N sends + complete) transparently.\n\nSource shapes:\n  • Local path:   `source: { type: \"path\", path: \"/abs/or/~/file.pdf\" }` (server reads the file directly — preferred for local files; filename is derived from the path if omitted).\n  • Base64 bytes: `source: { type: \"base64\", data: \"<b64 string>\" }`\n  • Public URL:   `source: { type: \"url\", url: \"https://example.com/file.pdf\" }` (the server fetches it server-side).\n\n`mode` defaults to \"single\"; only pass \"multi\" for files larger than ~5MB.",
   batchable: false,
   schema: UploadFileParams,
   example: {
@@ -155,19 +195,36 @@ register({
   },
   handler: tryHandler(async ({ mode, filename, content_type, source }) => {
     const effectiveMode = mode ?? "single";
+    // A path source carries its own name; fall back to the basename when the
+    // caller doesn't pass filename explicitly. base64/url have no name to
+    // derive, so filename stays required there.
+    const effectiveFilename =
+      filename ??
+      (source.type === "path" ? basename(expandHome(source.path)) : undefined);
+    if (!effectiveFilename) {
+      return {
+        ok: false,
+        error: {
+          code: "validation_error",
+          message:
+            "filename is required for base64 and url sources (there is no name to derive).",
+          fix: 'Pass `filename` (e.g. "report.pdf"), or use a path source to derive it from the path.',
+        },
+      };
+    }
     const notion = await getClient();
     const bytes = await resolveBytes(source);
     // Notion rejects send() when the Blob's MIME doesn't match the
     // content_type stored at create(), and rejects application/octet-stream
     // outright. Resolve a single MIME for both sides: caller's content_type
     // wins, else infer from the filename extension.
-    const effectiveType = content_type ?? inferContentType(filename);
+    const effectiveType = content_type ?? inferContentType(effectiveFilename);
     if (!effectiveType) {
       return {
         ok: false,
         error: {
           code: "validation_error",
-          message: `Could not infer content_type from filename "${filename}". Notion's File Upload API rejects application/octet-stream and only accepts a fixed allowlist of MIME types.`,
+          message: `Could not infer content_type from filename "${effectiveFilename}". Notion's File Upload API rejects application/octet-stream and only accepts a fixed allowlist of MIME types.`,
           fix: "Pass `content_type` explicitly (e.g. \"application/pdf\", \"image/png\", \"text/plain\"). See https://developers.notion.com/docs/working-with-files-and-media for the full list.",
         },
       };
@@ -176,13 +233,16 @@ register({
     if (effectiveMode === "single") {
       const createBody: CreateFileUploadBody = {
         mode: "single_part",
-        filename,
+        filename: effectiveFilename,
         content_type: effectiveType,
       };
       const created = await notion.fileUploads.create(createBody);
       const sendBody: SendFileUploadBody = {
         file_upload_id: created.id,
-        file: { filename, data: new Blob([bytes], { type: effectiveType }) },
+        file: {
+          filename: effectiveFilename,
+          data: new Blob([bytes], { type: effectiveType }),
+        },
       };
       const sent = await notion.fileUploads.send(sendBody);
       return { ok: true, data: slimFileUpload(sent) };
@@ -191,7 +251,7 @@ register({
     const parts = splitIntoParts(bytes);
     const createBody: CreateFileUploadBody = {
       mode: "multi_part",
-      filename,
+      filename: effectiveFilename,
       content_type: effectiveType,
       number_of_parts: parts.length,
     };
@@ -201,7 +261,10 @@ register({
       const partNumber = index + 1;
       const sendBody: SendFileUploadBody = {
         file_upload_id: created.id,
-        file: { filename, data: new Blob([part], { type: effectiveType }) },
+        file: {
+          filename: effectiveFilename,
+          data: new Blob([part], { type: effectiveType }),
+        },
         part_number: String(partNumber),
       };
       try {

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -193,6 +193,30 @@ describe("upload_file (single-part)", () => {
     expect(blob.type).toBe("text/plain");
   });
 
+  it.each([
+    ["notes.md", "text/markdown"],
+    ["deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"],
+    ["sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+    ["doc.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+  ])("infers content_type for %s", async (filename, expectedType) => {
+    notionStub.fileUploads.create.mockResolvedValue({ id: "fu-infer" });
+    notionStub.fileUploads.send.mockResolvedValue({
+      id: "fu-infer",
+      status: "uploaded",
+    });
+
+    await dispatch("upload_file", {
+      filename,
+      source: { type: "base64", data: Buffer.from("x").toString("base64") },
+    });
+
+    expect(notionStub.fileUploads.create).toHaveBeenCalledWith({
+      mode: "single_part",
+      filename,
+      content_type: expectedType,
+    });
+  });
+
   it("returns validation_error envelope when content_type is omitted and the extension isn't on the allowlist", async () => {
     const res = await dispatch("upload_file", {
       mode: "single",
@@ -343,6 +367,85 @@ describe("upload_file (URL source)", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────
+// upload_file: local path source
+// ──────────────────────────────────────────────────────────────────────────
+
+describe("upload_file (path source)", () => {
+  it("reads the file from disk and derives filename from the path basename", async () => {
+    const { mkdtemp, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = await mkdtemp(join(tmpdir(), "notion-upload-"));
+    const filePath = join(dir, "report.txt");
+    const payload = Buffer.from("local bytes on disk");
+    await writeFile(filePath, payload);
+
+    notionStub.fileUploads.create.mockResolvedValue({ id: "fu-path" });
+    notionStub.fileUploads.send.mockResolvedValue({
+      id: "fu-path",
+      status: "uploaded",
+    });
+
+    try {
+      const res = await dispatch("upload_file", {
+        source: { type: "path", path: filePath },
+      });
+
+      expect(res).toMatchObject({ ok: true });
+      // filename derived from basename, content_type inferred from .txt
+      expect(notionStub.fileUploads.create).toHaveBeenCalledWith({
+        mode: "single_part",
+        filename: "report.txt",
+        content_type: "text/plain",
+      });
+      expect((await sendBytes(0)).equals(payload)).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors an explicit filename over the path basename", async () => {
+    const { mkdtemp, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = await mkdtemp(join(tmpdir(), "notion-upload-"));
+    const filePath = join(dir, "tmpname.bin");
+    await writeFile(filePath, Buffer.from("x"));
+
+    notionStub.fileUploads.create.mockResolvedValue({ id: "fu-path2" });
+    notionStub.fileUploads.send.mockResolvedValue({
+      id: "fu-path2",
+      status: "uploaded",
+    });
+
+    try {
+      await dispatch("upload_file", {
+        filename: "real.txt",
+        source: { type: "path", path: filePath },
+      });
+      expect(notionStub.fileUploads.create).toHaveBeenCalledWith({
+        mode: "single_part",
+        filename: "real.txt",
+        content_type: "text/plain",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces the fs error when the path does not exist and makes no SDK calls", async () => {
+    const res = await dispatch("upload_file", {
+      source: { type: "path", path: "/no/such/file-xyz.txt" },
+    });
+    expect((res as { ok: boolean }).ok).toBe(false);
+    expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
+    expect(notionStub.fileUploads.send).not.toHaveBeenCalled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
 // upload_file: validation error path
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -367,6 +470,17 @@ describe("upload_file (validation)", () => {
     expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
     expect(notionStub.fileUploads.send).not.toHaveBeenCalled();
     expect(notionStub.fileUploads.complete).not.toHaveBeenCalled();
+  });
+
+  it("rejects a base64 source with no filename (nothing to derive) and makes no SDK calls", async () => {
+    const res = await dispatch("upload_file", {
+      source: { type: "base64", data: Buffer.from("x").toString("base64") },
+    });
+    assertErr(res);
+    expect(res.error.code).toBe("validation_error");
+    expect(res.error.message).toContain("filename is required");
+    expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
+    expect(notionStub.fileUploads.send).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a **`path` source** to `upload_file` so the server reads local files directly (`fs.readFile`) instead of receiving the bytes as base64 through the tool call.

For a local stdio server, the base64 path forces the entire file to travel through the MCP client (and, in agent setups, be emitted by the model as base64 output tokens — ~33% larger than the file). For non-trivial files this dominates upload latency and, for large files, makes uploads impractical. Reading from a path skips that entirely — bytes go straight from disk to Notion's `file_uploads` API.

```jsonc
// before
{ "source": { "type": "base64", "data": "<~14MB of base64 for a 10MB PDF>" }, "filename": "spec.pdf", "content_type": "application/pdf" }

// after
{ "source": { "type": "path", "path": "~/docs/spec.pdf" } }
```

### Details
- **`path` source**: reads the file server-side; supports `~`/`~/` expansion (Node's `fs` doesn't).
- **`filename` now optional** — derived from the path basename for `path` sources. Still required for `base64`/`url` (no name to infer), with a clear `validation_error` if missing.
- **Extended content_type inference** allowlist: `md`/`markdown` and Microsoft Office formats (`doc`, `docx`, `ppt`, `pptx`, `xls`, `xlsx`), so these upload without an explicit `content_type`.

This is purely additive — `base64` and `url` sources are unchanged.

## Testing
`npm test` → all green (added 8 tests):
- path read + basename-derived filename
- explicit filename overrides basename
- nonexistent path surfaces the fs error, makes no SDK calls
- base64 source without filename is rejected (no SDK calls)
- MIME inference for `md`, `pptx`, `xlsx`, `docx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
