### PR TITLE
fix(schema): give $defs bodies a real shape, not a self-$ref

### DIFF
--- a/src/schema/emit.ts
+++ b/src/schema/emit.ts
@@ -47,6 +47,14 @@ function hoistSharedRefs(root: JsonSchema): JsonSchema {
       usedNames.add(match);
       return { $ref: `#/$defs/${match}` };
     }
+    return walkChildren(obj);
+  }
+
+  // Walk into a node without testing the node itself for a shared-ref match.
+  // A definition body is the one place that must not become a $ref: matching
+  // there emits `$defs.parent = {$ref: "#/$defs/parent"}`, which resolves to
+  // itself and hides the shape it exists to publish.
+  function walkChildren(obj: Record<string, unknown>): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) out[k] = walk(v);
     return out;
@@ -56,8 +64,10 @@ function hoistSharedRefs(root: JsonSchema): JsonSchema {
   if (usedNames.size === 0) return walked;
 
   const defs: Record<string, unknown> = walked.$defs ?? {};
+  // usedNames grows if one definition body references another. A for-of over a
+  // Set visits entries added during iteration, so those get bodies too.
   for (const name of usedNames) {
-    if (!(name in defs)) defs[name] = walk(sharedSchemas[name]);
+    if (!(name in defs)) defs[name] = walkChildren(sharedSchemas[name]);
   }
   return { ...walked, $defs: defs };
 }

--- a/tests/schema-emit.test.ts
+++ b/tests/schema-emit.test.ts
@@ -28,3 +28,29 @@ describe("emitJsonSchema", () => {
     expect(props.c.type).toBe("string");
   });
 });
+
+describe("emitJsonSchema $defs bodies", () => {
+  it("gives a definition a real body, not a $ref to itself", () => {
+    const Inner = z.object({ id: z.string(), label: z.string() });
+    registerSharedRef("gadget", Inner);
+
+    const json = emitJsonSchema(z.object({ a: Inner, b: Inner }));
+    const body = (json.$defs as any).gadget;
+    expect(body.$ref).toBeUndefined();
+    expect(body.type).toBe("object");
+    expect(Object.keys(body.properties)).toEqual(["id", "label"]);
+  });
+
+  it("resolves a nested shared ref inside a definition body", () => {
+    const Leaf = z.object({ url: z.string() });
+    const Branch = z.object({ leaf: Leaf, name: z.string() });
+    registerSharedRef("leaf", Leaf);
+    registerSharedRef("branch", Branch);
+
+    const json = emitJsonSchema(z.object({ x: Branch }));
+    const defs = json.$defs as any;
+    expect(defs.branch.$ref).toBeUndefined();
+    expect(defs.branch.properties.leaf).toEqual({ $ref: "#/$defs/leaf" });
+    expect(defs.leaf.properties.url.type).toBe("string");
+  });
+});


### PR DESCRIPTION
`hoistSharedRefs` walked each definition body through the same matcher it used for call sites. The body matched itself, so `$defs.parent` came out as `{"$ref": "#/$defs/parent"}`. `parent`, `icon` and `file` all resolved to themselves, and `notion_describe` could not teach the parent shape to a caller.

Before, without any discoverability:

```json
"$defs": {
  "parent": { "$ref": "#/$defs/parent" },
  "icon":   { "$ref": "#/$defs/icon"   },
  "file":   { "$ref": "#/$defs/file"   }
}
```

After:

```json
"$defs": {
  "parent": {
    "anyOf": [
      { "properties": { "type": {"const": "page_id"},        "page_id": {"type": "string"} },        "required": ["type","page_id"] },
      { "properties": { "type": {"const": "database_id"},    "database_id": {"type": "string"} },    "required": ["type","database_id"] },
      { "properties": { "type": {"const": "data_source_id"}, "data_source_id": {"type": "string"} }, "required": ["type","data_source_id"] },
      { "properties": { "type": {"const": "workspace"},      "workspace": {"const": true} },         "required": ["type","workspace"] },
      { "properties": { "type": {"const": "block_id"},       "block_id": {"type": "string"} },       "required": ["type","block_id"] }
    ]
  },
  "icon": { "properties": { "type": {"const": "emoji"}, "emoji": {} }, "required": ["type","emoji"] }
}
```

Adds tests that fail without the fix. Suite stays green.
