### PR TITLE
feat(blocks): validate children structurally

### DIFF
--- a/src/operations/blocks.ts
+++ b/src/operations/blocks.ts
@@ -12,6 +12,7 @@ import {
   type AppendBlockChildren,
   type UpdateBlockBody,
 } from "../utils/notion-types.js";
+import { BLOCK_INPUT_SCHEMA } from "../schema/blocks.js";
 
 const VERBOSE = z.boolean().optional();
 
@@ -23,7 +24,7 @@ const AppendBlocksParams = z
   .object({
     block_id: z.string().describe("Parent page ID or block ID to append into."),
     markdown: z.string().optional().describe("Content to append, as markdown. Parsed server-side."),
-    children: z.array(z.unknown()).optional().describe("Structured Notion blocks. Mutually exclusive with markdown."),
+    children: z.array(BLOCK_INPUT_SCHEMA).optional().describe("Structured Notion blocks. Mutually exclusive with markdown."),
     after: z.string().optional().describe("Append immediately after this block ID (legacy ordering)."),
     position: z.enum(["start", "end"]).optional().describe("Append at start or end. Preferred over `after`."),
     verbose: VERBOSE,
@@ -298,7 +299,7 @@ const MixedOp = z.discriminatedUnion("op", [
     op: z.literal("append"),
     block_id: z.string(),
     markdown: z.string().optional(),
-    children: z.array(z.unknown()).optional(),
+    children: z.array(BLOCK_INPUT_SCHEMA).optional(),
   }),
   z.object({
     op: z.literal("update"),

--- a/src/operations/pages.ts
+++ b/src/operations/pages.ts
@@ -34,6 +34,7 @@ import {
   URL_PROPERTY_VALUE_SCHEMA,
   VERIFICATION_PROPERTY_VALUE_SCHEMA,
 } from "../schema/page-properties.js";
+import { BLOCK_INPUT_SCHEMA } from "../schema/blocks.js";
 
 const VERBOSE = z.boolean().optional();
 
@@ -74,7 +75,7 @@ const CreatePageParams = z
     title: z.string().optional().describe("Shortcut for setting the title property."),
     properties: z.record(z.string(), PROPERTY_VALUE_SCHEMA).optional(),
     markdown: z.string().optional().describe("Page body as markdown. Parsed server-side."),
-    children: z.array(z.unknown()).optional().describe("Structured Notion blocks. Mutually exclusive with markdown."),
+    children: z.array(BLOCK_INPUT_SCHEMA).optional().describe("Structured Notion blocks. Mutually exclusive with markdown."),
     template: z
       .object({
         type: z.enum(["default", "none", "template_id"]).describe("`template_id` to apply a specific template, `default` for the data source's default template, `none` for no template."),

--- a/src/schema/blocks.ts
+++ b/src/schema/blocks.ts
@@ -178,3 +178,21 @@ export const TEXT_BLOCK_REQUEST_SCHEMA = z.preprocess(
     .describe("Union of all possible text block request types")
 );
 
+
+// A structural check, not a whitelist. Notion has more than thirty block types
+// and adds more, so an enum here would reject a valid block the day Notion
+// ships one. Requiring `type` plus a body keyed by it catches what callers
+// actually get wrong: a misspelled type, and a block with no body.
+export const BLOCK_INPUT_SCHEMA = z
+  .looseObject({
+    type: z.string().describe('Block type, e.g. "paragraph", "image", "table".'),
+  })
+  .refine((b) => Object.hasOwn(b, b.type), {
+    error: (issue) => {
+      const type = (issue.input as { type?: string })?.type;
+      return `Block has no "${type}" body. A block is { "type": "${type}", "${type}": { ... } }.`;
+    },
+  })
+  .describe(
+    'A Notion block: { "type": "<name>", "<name>": { ... } }. Prefer `markdown` for prose.'
+  );

--- a/tests/schema-emit.test.ts
+++ b/tests/schema-emit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { BLOCK_INPUT_SCHEMA } from "../src/schema/blocks.js";
 import { z } from "zod";
 import { emitJsonSchema, registerSharedRef } from "../src/schema/emit.js";
 
@@ -26,5 +27,28 @@ describe("emitJsonSchema", () => {
     expect(props.a).toEqual({ $ref: "#/$defs/widget" });
     expect(props.b).toEqual({ $ref: "#/$defs/widget" });
     expect(props.c.type).toBe("string");
+  });
+});
+
+describe("BLOCK_INPUT_SCHEMA", () => {
+  it("takes any block whose body matches its type", () => {
+    for (const block of [
+      { type: "paragraph", paragraph: { rich_text: [] } },
+      { type: "image", image: { type: "file_upload", file_upload: { id: "x" } } },
+      // A type this server has no zod schema for still passes.
+      { type: "table", table: { table_width: 2 } },
+    ]) {
+      expect(BLOCK_INPUT_SCHEMA.safeParse(block).success).toBe(true);
+    }
+  });
+
+  it("rejects a misspelled type and names the missing body", () => {
+    const res = BLOCK_INPUT_SCHEMA.safeParse({ type: "parragraph", text: "x" });
+    expect(res.success).toBe(false);
+    expect(res.error!.issues[0].message).toContain('no "parragraph" body');
+  });
+
+  it("rejects a block with no type", () => {
+    expect(BLOCK_INPUT_SCHEMA.safeParse({ paragraph: {} }).success).toBe(false);
   });
 });


### PR DESCRIPTION
Minor fix to the schema, where the children of a block is `z.array(z.unknown())` instead of a block.