### PR TITLE
feat: add durable idempotency receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you just want to chat with your Notion in claude.ai's web UI, use Notion's ho
 | **Operations covered** | ~24 endpoints | **43 operations** (plus a `trash_page` alias) across pages, blocks, databases, data sources, views, templates, comments, users, files |
 | **Batch mutations** | Not documented | ✅ Universal `{ items: [...] }` envelope; up to **10 in parallel** |
 | **Atomic batches + rollback** | Not documented | ✅ `atomic: true` aborts on first failure, best-effort archives entities created earlier |
-| **Idempotency** | Not documented | ✅ `idempotency_key` — same key + op returns the cached result for 5 minutes |
+| **Idempotency** | Not documented | ✅ Durable `idempotency_key` receipts survive restarts, deduplicate identical replay, and reject conflicting reuse |
 | **Rate-limit handling** | 429s bubble up | ✅ Token-bucket limiter (3 req/s default) + exponential backoff, honors `Retry-After` |
 | **Response shapes** | Raw Notion SDK JSON | **Slim shapers** drop noise by default; `verbose: true` opts out |
 | **Database queries** | Raw `properties` bag per row | **Flattened** name → primitive map (all 20+ property types) |
@@ -245,6 +245,9 @@ Official reference: [PAT guide](https://developers.notion.com/guides/get-started
 | `NOTION_TOKEN` | ✅ | — | PAT (`ntn_…`, recommended) or Internal Integration secret (`secret_…` / `ntn_…`) |
 | `NOTION_PAGE_ID` | — | — | Default parent for `create_page` / `create_database` when no `parent` is passed (page → Share → Copy link; ID = last 32 chars) |
 | `NOTION_RATE_LIMIT` | — | `3` | Requests/second for the shared limiter (Notion's documented per-integration limit) |
+| `NOTION_IDEMPOTENCY_STATE_PATH` | — | `~/.notion-mcp-server/idempotency-ledger.json` | Durable keyed-batch receipt ledger |
+| `NOTION_IDEMPOTENCY_TTL_MS` | — | `2592000000` (30 days) | Retention for completed receipts; pending entries are never auto-pruned |
+| `NOTION_IDEMPOTENCY_MAX_ENTRIES` | — | `2048` | Maximum completed receipts retained on disk |
 | `NOTION_READ_ONLY` | — | — | `true`/`1`/`yes` disables every write operation in one switch |
 | `NOTION_ALLOWED_OPERATIONS` | — | all | Comma-separated allowlist of operations or group presets — see [Restricting operations](#restricting-operations) |
 | `NOTION_BLOCKED_OPERATIONS` | — | — | Comma-separated blocklist (same vocabulary); wins over the allowlist |
@@ -360,7 +363,7 @@ docker run --rm -e NOTION_TOKEN=ntn_xxx -e MCP_TRANSPORT=http -p 3000:3000 ghcr.
 - **Two-tool surface** — `notion_execute` (do it) + `notion_describe` (learn the shape). The whole API is one schema deep.
 - **Universal batch envelope** — every mutating op accepts `{ items: [...], atomic?, idempotency_key?, concurrency? }` with per-item validation and results.
 - **Atomic batches with best-effort rollback** — `atomic: true` aborts on first failure and archives anything created earlier in the batch.
-- **Idempotency keys** — same `(operation, idempotency_key)` returns the cached result for 5 minutes. Safe to retry on flaky networks.
+- **Durable idempotency receipts** — keyed batches survive process restarts, deduplicate identical replay, reject conflicting key reuse, and block replay while a prior outcome is uncertain.
 - **Rate-limit + retry baked in** — token-bucket limiter (3 req/s default, `NOTION_RATE_LIMIT` to change) with exponential backoff on 429/5xx/timeouts, honoring `Retry-After`.
 - **Self-healing validation errors** — failures return `{ schema, example, fix }` so the model corrects bad payloads in one round-trip.
 - **Markdown everywhere** — `create_page` / `append_blocks` / `update_block` / comment bodies accept a `markdown` string (full GFM: headings 1–4, lists, nested to-dos, blockquotes, fenced code with language detection, images, dividers, inline formatting), plus full round-trip via `get_page_markdown` / `update_page_markdown`.
@@ -388,6 +391,8 @@ Run any operation: `{ operation, payload }`, where payload is a single object or
   "payload": { "page_id": "<page-id>", "title": "Q3 plan" }
 }
 ```
+
+Keyed batches run serially so ledger failure cannot race with later mutations. Responses include an additive `idempotency_receipt`. The on-disk ledger stores request fingerprints and privacy-sanitized results, never raw keys, payload text, titles, URLs, credentials, or tokens. If a prior process stopped after a downstream attempt but before durable completion, replay fails with `idempotency_indeterminate`; reconcile Notion before authorizing a new key.
 
 ```jsonc
 // batch
@@ -522,7 +527,7 @@ claude mcp add notion -s user \
 - Zod 4 payload validation; emits draft-7 JSON Schema with `$defs` deduplication for error envelopes
 - Markdown → Notion blocks via `remark` / `remark-gfm`
 - Bounded-concurrency batch worker (default 3, max 10); shared token-bucket rate limiter; `withRetry` with exponential backoff around every dispatched call
-- In-memory idempotency cache (5-minute TTL, 512 entries)
+- Atomic, lock-protected idempotency ledger (30-day completed-receipt TTL, 2,048 entries by default)
 - Slim shapers per entity type with `verbose: true` opt-out
 - Vitest suite covering the markdown parser, shapers, schema emitter, dispatcher, batch semantics (partial success / atomic rollback / idempotency), access control, and HTTP transport
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,21 +755,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1334,9 +1347,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1588,9 +1601,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2948,9 +2961,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3178,9 +3191,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -3198,7 +3211,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/dispatch/idempotency.ts
+++ b/src/dispatch/idempotency.ts
@@ -1,42 +1,524 @@
-type CacheEntry = { result: unknown; expiresAt: number };
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 
-const TTL_MS = 5 * 60 * 1000;
-const MAX_ENTRIES = 512;
+const LEDGER_VERSION = 1;
+const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 2048;
+const LOCK_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 10_000;
+const ENFORCING_LAYER = "notion-mcp-server:dispatch-v1";
 
-const cache = new Map<string, CacheEntry>();
+type LedgerState = "pending" | "completed";
 
-function evictExpired(now: number): void {
-  for (const [key, entry] of cache) {
-    if (entry.expiresAt <= now) cache.delete(key);
+type LedgerEntry = {
+  receipt_id: string;
+  operation: string;
+  key_hash: string;
+  request_fingerprint: string;
+  state: LedgerState;
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+  submitted_attempt_count: number;
+  downstream_write_count: number;
+  stored_result?: unknown;
+  effect_identifiers?: string[];
+};
+
+type Ledger = {
+  version: number;
+  salt: string;
+  entries: Record<string, LedgerEntry>;
+};
+
+export type IdempotencyDecision =
+  | "accepted"
+  | "deduplicated"
+  | "rejected"
+  | "indeterminate";
+
+export type IdempotencyReceipt = {
+  receipt_id: string;
+  decision: IdempotencyDecision;
+  operation: string;
+  key_hash: string;
+  request_fingerprint: string;
+  state: LedgerState | "indeterminate";
+  submitted_attempt_count: number;
+  downstream_write_count: number;
+  effect_identifiers: string[];
+  enforcing_layer: string;
+  replay_of?: string;
+  reason?: string;
+};
+
+export type IdempotencyContext = {
+  entry_key: string;
+  receipt_id: string;
+  operation: string;
+  key_hash: string;
+  request_fingerprint: string;
+};
+
+type Admission =
+  | { action: "accepted"; context: IdempotencyContext }
+  | {
+      action: "deduplicated";
+      receipt: IdempotencyReceipt;
+      stored_result: unknown;
+    }
+  | {
+      action: "rejected" | "indeterminate";
+      receipt: IdempotencyReceipt;
+      error: { code: string; message: string; fix: string };
+    };
+
+let mutationQueue = Promise.resolve();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function statePath(): string {
+  return (
+    process.env.NOTION_IDEMPOTENCY_STATE_PATH ||
+    join(homedir(), ".notion-mcp-server", "idempotency-ledger.json")
+  );
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, item]) => item !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, item]) => [key, canonicalize(item)])
+    );
   }
-  if (cache.size > MAX_ENTRIES) {
-    const overflow = cache.size - MAX_ENTRIES;
-    let removed = 0;
-    for (const key of cache.keys()) {
-      if (removed >= overflow) break;
-      cache.delete(key);
-      removed++;
+  if (typeof value === "number" && !Number.isFinite(value)) return String(value);
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requestFingerprint(operation: string, payload: unknown): string {
+  return sha256(stableJson({ operation, payload }));
+}
+
+function newLedger(): Ledger {
+  return {
+    version: LEDGER_VERSION,
+    salt: randomBytes(32).toString("hex"),
+    entries: {},
+  };
+}
+
+function isLedger(value: unknown): value is Ledger {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Ledger>;
+  return (
+    candidate.version === LEDGER_VERSION &&
+    typeof candidate.salt === "string" &&
+    candidate.salt.length >= 32 &&
+    !!candidate.entries &&
+    typeof candidate.entries === "object" &&
+    !Array.isArray(candidate.entries)
+  );
+}
+
+function infrastructureError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
+
+async function readLedgerCandidate(path: string): Promise<Ledger | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    return isLedger(parsed) ? parsed : null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    return null;
+  }
+}
+
+async function loadLedger(path: string): Promise<Ledger> {
+  const canonical = await readLedgerCandidate(path);
+  if (canonical) return canonical;
+
+  const recoveryPath = `${path}.tmp`;
+  const recovery = await readLedgerCandidate(recoveryPath);
+  if (recovery) {
+    await rm(path, { force: true });
+    await rename(recoveryPath, path);
+    return recovery;
+  }
+
+  try {
+    await stat(path);
+    throw infrastructureError(
+      "idempotency_ledger_corrupt",
+      `The idempotency ledger is invalid: ${path}`
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return newLedger();
+}
+
+async function atomicWriteLedger(path: string, ledger: Ledger): Promise<void> {
+  const temporaryPath = `${path}.tmp`;
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true });
+
+  const handle = await open(temporaryPath, "w", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(ledger)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  try {
+    await rename(temporaryPath, path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!code || !["EACCES", "EEXIST", "EPERM"].includes(code)) throw error;
+    await rm(path, { force: true });
+    await rename(temporaryPath, path);
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function staleLock(lockPath: string): Promise<boolean> {
+  try {
+    const [metadata, raw] = await Promise.all([
+      stat(lockPath),
+      readFile(lockPath, "utf8").catch(() => ""),
+    ]);
+    const pid = Number(raw.trim());
+    if (Date.now() - metadata.mtimeMs > LOCK_STALE_MS) return true;
+    return Number.isSafeInteger(pid) && pid > 0 && !isProcessAlive(pid);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
+async function acquireLock(path: string): Promise<() => Promise<void>> {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  await mkdir(dirname(path), { recursive: true });
+
+  while (Date.now() < deadline) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      await handle.writeFile(String(process.pid), "utf8");
+      await handle.sync();
+      return async () => {
+        await handle.close();
+        await rm(lockPath, { force: true });
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (await staleLock(lockPath)) {
+        await rm(lockPath, { force: true });
+        continue;
+      }
+      await sleep(40);
     }
   }
+  throw infrastructureError(
+    "idempotency_lock_timeout",
+    `Timed out waiting for the idempotency ledger lock: ${lockPath}`
+  );
 }
 
-export function lookup(key: string): unknown | undefined {
-  const now = Date.now();
-  const entry = cache.get(key);
-  if (!entry) return undefined;
-  if (entry.expiresAt <= now) {
-    cache.delete(key);
+function pruneLedger(ledger: Ledger): void {
+  const ttl = positiveInteger(process.env.NOTION_IDEMPOTENCY_TTL_MS, DEFAULT_TTL_MS);
+  const maxEntries = positiveInteger(
+    process.env.NOTION_IDEMPOTENCY_MAX_ENTRIES,
+    DEFAULT_MAX_ENTRIES
+  );
+  const cutoff = Date.now() - ttl;
+  const completed = Object.entries(ledger.entries)
+    .filter(([, entry]) => entry.state === "completed")
+    .sort(([, a], [, b]) => Date.parse(a.updated_at) - Date.parse(b.updated_at));
+
+  for (const [key, entry] of completed) {
+    if (Date.parse(entry.updated_at) < cutoff) delete ledger.entries[key];
+  }
+
+  const remainingCompleted = Object.entries(ledger.entries)
+    .filter(([, entry]) => entry.state === "completed")
+    .sort(([, a], [, b]) => Date.parse(a.updated_at) - Date.parse(b.updated_at));
+  const overflow = Math.max(0, remainingCompleted.length - maxEntries);
+  for (const [key] of remainingCompleted.slice(0, overflow)) delete ledger.entries[key];
+}
+
+async function withLedgerMutation<T>(mutator: (ledger: Ledger) => Promise<T>): Promise<T> {
+  const run = async (): Promise<T> => {
+    const path = statePath();
+    let release: (() => Promise<void>) | undefined;
+    try {
+      release = await acquireLock(path);
+      const ledger = await loadLedger(path);
+      pruneLedger(ledger);
+      const value = await mutator(ledger);
+      await atomicWriteLedger(path, ledger);
+      return value;
+    } finally {
+      await release?.();
+    }
+  };
+
+  const task = mutationQueue.then(run, run);
+  mutationQueue = task.then(
+    () => undefined,
+    () => undefined
+  );
+  return task;
+}
+
+const SENSITIVE_KEY =
+  /(token|secret|authorization|cookie|password|credential|signed|content|markdown|rich_text|plain_text|caption|title|name|url|href)/i;
+const SAFE_LITERAL_STRING_KEY = /^(code|type|object|status|state|decision|operation)$/i;
+const SAFE_IDENTIFIER_KEY =
+  /^(id|ids|page_id|block_id|database_id|data_source_id|receipt_id|replay_of)$/i;
+const SAFE_IDENTIFIER_VALUE =
+  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+function isSafeIdentifier(value: unknown): value is string {
+  return typeof value === "string" && SAFE_IDENTIFIER_VALUE.test(value);
+}
+
+function sanitizeResult(value: unknown, key = ""): unknown {
+  if (value === null || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    if (SAFE_LITERAL_STRING_KEY.test(key)) return value;
+    if (SAFE_IDENTIFIER_KEY.test(key) && isSafeIdentifier(value)) return value;
     return undefined;
   }
-  return entry.result;
+  if (Array.isArray(value)) {
+    const sanitized = value
+      .map((item) => sanitizeResult(item, key))
+      .filter((item) => item !== undefined);
+    return sanitized;
+  }
+  if (!value || typeof value !== "object") return undefined;
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEY.test(childKey)) continue;
+    const child = sanitizeResult(childValue, childKey);
+    if (child !== undefined) sanitized[childKey] = child;
+  }
+  return sanitized;
 }
 
-export function store(key: string, result: unknown): void {
-  const now = Date.now();
-  evictExpired(now);
-  cache.set(key, { result, expiresAt: now + TTL_MS });
+function collectEffectIdentifiers(value: unknown, output = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) collectEffectIdentifiers(item, output);
+    return output;
+  }
+  if (!value || typeof value !== "object") return output;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (SAFE_IDENTIFIER_KEY.test(key) && isSafeIdentifier(child)) output.add(child);
+    collectEffectIdentifiers(child, output);
+  }
+  return output;
 }
 
-export function buildKey(operation: string, idempotencyKey: string): string {
-  return `${operation}::${idempotencyKey}`;
+function receiptFrom(
+  entry: LedgerEntry,
+  decision: IdempotencyDecision,
+  replayOf?: string,
+  reason?: string
+): IdempotencyReceipt {
+  return {
+    receipt_id: entry.receipt_id,
+    decision,
+    operation: entry.operation,
+    key_hash: entry.key_hash.slice(0, 16),
+    request_fingerprint: entry.request_fingerprint,
+    state: decision === "indeterminate" ? "indeterminate" : entry.state,
+    submitted_attempt_count: entry.submitted_attempt_count,
+    downstream_write_count: entry.downstream_write_count,
+    effect_identifiers: entry.effect_identifiers ?? [],
+    enforcing_layer: ENFORCING_LAYER,
+    ...(replayOf ? { replay_of: replayOf } : {}),
+    ...(reason ? { reason } : {}),
+  };
+}
+
+export async function beginIdempotentRequest(
+  operation: string,
+  payload: unknown,
+  rawKey: string
+): Promise<Admission> {
+  return withLedgerMutation(async (ledger) => {
+    const keyHash = sha256(`${ledger.salt}\0${operation}\0${rawKey}`);
+    const entryKey = `${operation}::${keyHash}`;
+    const fingerprint = requestFingerprint(operation, payload);
+    const existing = ledger.entries[entryKey];
+
+    if (existing) {
+      existing.submitted_attempt_count++;
+      existing.updated_at = new Date().toISOString();
+      if (existing.request_fingerprint !== fingerprint) {
+        return {
+          action: "rejected",
+          receipt: receiptFrom(existing, "rejected"),
+          error: {
+            code: "idempotency_conflict",
+            message: "This idempotency key was already used with a different payload.",
+            fix: "Use the original payload, or use a new explicitly authorized idempotency key.",
+          },
+        };
+      }
+      if (existing.state === "completed") {
+        return {
+          action: "deduplicated",
+          receipt: receiptFrom(existing, "deduplicated", existing.receipt_id),
+          stored_result: existing.stored_result,
+        };
+      }
+      return {
+        action: "indeterminate",
+        receipt: receiptFrom(
+          existing,
+          "indeterminate",
+          existing.receipt_id,
+          "A prior attempt is still pending."
+        ),
+        error: {
+          code: "idempotency_indeterminate",
+          message: "A prior attempt may have reached Notion, so automatic replay is blocked.",
+          fix: "Reconcile authoritative Notion state before using a new explicitly authorized key.",
+        },
+      };
+    }
+
+    const now = new Date().toISOString();
+    const entry: LedgerEntry = {
+      receipt_id: randomUUID(),
+      operation,
+      key_hash: keyHash,
+      request_fingerprint: fingerprint,
+      state: "pending",
+      created_at: now,
+      updated_at: now,
+      submitted_attempt_count: 1,
+      downstream_write_count: 0,
+    };
+    ledger.entries[entryKey] = entry;
+    return {
+      action: "accepted",
+      context: {
+        entry_key: entryKey,
+        receipt_id: entry.receipt_id,
+        operation,
+        key_hash: keyHash,
+        request_fingerprint: fingerprint,
+      },
+    };
+  });
+}
+
+export async function markDownstreamAttempt(context: IdempotencyContext): Promise<void> {
+  await withLedgerMutation(async (ledger) => {
+    const entry = ledger.entries[context.entry_key];
+    if (!entry || entry.receipt_id !== context.receipt_id || entry.state !== "pending") {
+      throw infrastructureError(
+        "idempotency_context_invalid",
+        "The durable idempotency context is missing or no longer pending."
+      );
+    }
+    entry.downstream_write_count++;
+    entry.updated_at = new Date().toISOString();
+  });
+}
+
+export async function completeIdempotentRequest(
+  context: IdempotencyContext,
+  result: unknown
+): Promise<IdempotencyReceipt> {
+  return withLedgerMutation(async (ledger) => {
+    const entry = ledger.entries[context.entry_key];
+    if (!entry || entry.receipt_id !== context.receipt_id || entry.state !== "pending") {
+      throw infrastructureError(
+        "idempotency_context_invalid",
+        "The durable idempotency context is missing or no longer pending."
+      );
+    }
+    const sanitized = sanitizeResult(result);
+    entry.stored_result = sanitized;
+    entry.effect_identifiers = [...collectEffectIdentifiers(sanitized)];
+    entry.state = "completed";
+    entry.completed_at = new Date().toISOString();
+    entry.updated_at = entry.completed_at;
+    return receiptFrom(entry, "accepted");
+  });
+}
+
+export function attachIdempotencyReceipt<T extends object>(
+  result: T,
+  receipt: IdempotencyReceipt
+): T & { idempotency_receipt: IdempotencyReceipt } {
+  return { ...result, idempotency_receipt: receipt };
+}
+
+export function ephemeralIndeterminateReceipt(
+  operation: string,
+  payload: unknown,
+  reason: string,
+  context?: Partial<IdempotencyContext>
+): IdempotencyReceipt {
+  return {
+    receipt_id: context?.receipt_id ?? randomUUID(),
+    decision: "indeterminate",
+    operation,
+    key_hash: context?.key_hash?.slice(0, 16) ?? "unavailable",
+    request_fingerprint:
+      context?.request_fingerprint ?? requestFingerprint(operation, payload),
+    state: "indeterminate",
+    submitted_attempt_count: 1,
+    downstream_write_count: 0,
+    effect_identifiers: [],
+    enforcing_layer: ENFORCING_LAYER,
+    reason,
+  };
+}
+
+export function isIdempotencyInfrastructureError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { code?: unknown }).code === "string" &&
+    (error as { code: string }).code.startsWith("idempotency_")
+  );
 }

--- a/src/dispatch/index.ts
+++ b/src/dispatch/index.ts
@@ -7,7 +7,16 @@ import type {
   OperationError,
   OperationResult,
 } from "../operations/types.js";
-import { buildKey, lookup, store } from "./idempotency.js";
+import {
+  attachIdempotencyReceipt,
+  beginIdempotentRequest,
+  completeIdempotentRequest,
+  ephemeralIndeterminateReceipt,
+  isIdempotencyInfrastructureError,
+  markDownstreamAttempt,
+  type IdempotencyContext,
+  type IdempotencyReceipt,
+} from "./idempotency.js";
 import { mapWithConcurrency } from "./concurrency.js";
 import { rateLimiter } from "./rate-limit.js";
 import { isRetryableErrorCode, withRetry } from "./retry.js";
@@ -31,6 +40,14 @@ type BatchPayload = {
   concurrency?: number;
 };
 
+type IdempotencyFailure = {
+  ok: false;
+  error: OperationError;
+  idempotency_receipt: IdempotencyReceipt;
+};
+
+type DispatchResult = OperationResult | BatchResult | IdempotencyFailure;
+
 function isBatchPayload(payload: RawPayload): payload is BatchPayload {
   return (
     typeof payload === "object" &&
@@ -50,7 +67,7 @@ function unknownOperationError(name: string): OperationError {
 export async function dispatch(
   operationName: string,
   payload: RawPayload
-): Promise<OperationResult | BatchResult> {
+): Promise<DispatchResult> {
   const def = getOperation(operationName);
   if (!def) {
     return { ok: false, error: unknownOperationError(operationName) };
@@ -125,11 +142,39 @@ async function runSingle(
 async function runBatch(
   def: OperationDef,
   payload: BatchPayload
-): Promise<BatchResult> {
+): Promise<OperationResult | BatchResult | IdempotencyFailure> {
   const idempotencyKey = payload.idempotency_key;
-  if (idempotencyKey) {
-    const cached = lookup(buildKey(def.name, idempotencyKey));
-    if (cached) return cached as BatchResult;
+  let idempotencyContext: IdempotencyContext | undefined;
+  if (idempotencyKey !== undefined) {
+    if (typeof idempotencyKey !== "string" || !idempotencyKey.trim() || idempotencyKey.length > 256) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_idempotency_key",
+          message: "idempotency_key must be a non-empty string of at most 256 characters.",
+          fix: "Provide a stable, non-secret key for this batch request.",
+        },
+      };
+    }
+    try {
+      const admission = await beginIdempotentRequest(def.name, payload, idempotencyKey);
+      if (admission.action === "deduplicated") {
+        return attachIdempotencyReceipt(
+          admission.stored_result as BatchResult,
+          admission.receipt
+        );
+      }
+      if (admission.action === "accepted") {
+        idempotencyContext = admission.context;
+      } else {
+        return attachIdempotencyReceipt(
+          { ok: false, error: admission.error },
+          admission.receipt
+        );
+      }
+    } catch (error) {
+      return indeterminateResult(def.name, payload, error);
+    }
   }
 
   const atomic = payload.atomic === true;
@@ -138,58 +183,71 @@ async function runBatch(
   // already started in-flight requests, so later items execute when they
   // shouldn't. Force concurrency=1 to make the abort barrier reliable.
   const requested = payload.concurrency ?? DEFAULT_CONCURRENCY;
-  const concurrency = atomic ? 1 : Math.max(1, Math.min(requested, MAX_CONCURRENCY));
+  const concurrency =
+    atomic || idempotencyContext
+      ? 1
+      : Math.max(1, Math.min(requested, MAX_CONCURRENCY));
   const items = payload.items;
   const createdForRollback: { item: BatchItemResult }[] = [];
 
   let aborted = false;
-  const results = await mapWithConcurrency(items, concurrency, async (item, index) => {
-    if (aborted) {
-      return {
-        index,
-        ok: false as const,
-        error: {
-          code: "aborted",
-          message: "Skipped: a prior item failed in atomic batch.",
-        },
-      };
-    }
-
-    const parsed = def.schema.safeParse(item);
-    if (!parsed.success) {
-      const failure: BatchItemResult = {
-        index,
-        ok: false,
-        error: buildValidationError(def, parsed.error),
-      };
-      if (atomic) aborted = true;
-      return failure;
-    }
-
-    try {
-      const result = await runHandlerWithLimitAndRetry(def, parsed.data);
-      if (result.ok) {
-        const success: BatchItemResult = { index, ok: true, data: result.data };
-        if (atomic && def.rollback) createdForRollback.push({ item: success });
-        return success;
+  let results: BatchItemResult[];
+  try {
+    results = await mapWithConcurrency(items, concurrency, async (item, index) => {
+      if (aborted) {
+        return {
+          index,
+          ok: false as const,
+          error: {
+            code: "aborted",
+            message: "Skipped: a prior item failed in atomic batch.",
+          },
+        };
       }
-      const failure: BatchItemResult = {
-        index,
-        ok: false,
-        error: result.error,
-      };
-      if (atomic) aborted = true;
-      return failure;
-    } catch (error) {
-      const failure: BatchItemResult = {
-        index,
-        ok: false,
-        error: toErrorEnvelope(error),
-      };
-      if (atomic) aborted = true;
-      return failure;
+
+      const parsed = def.schema.safeParse(item);
+      if (!parsed.success) {
+        const failure: BatchItemResult = {
+          index,
+          ok: false,
+          error: buildValidationError(def, parsed.error),
+        };
+        if (atomic) aborted = true;
+        return failure;
+      }
+
+      try {
+        if (idempotencyContext) await markDownstreamAttempt(idempotencyContext);
+        const result = await runHandlerWithLimitAndRetry(def, parsed.data);
+        if (result.ok) {
+          const success: BatchItemResult = { index, ok: true, data: result.data };
+          if (atomic && def.rollback) createdForRollback.push({ item: success });
+          return success;
+        }
+        const failure: BatchItemResult = {
+          index,
+          ok: false,
+          error: result.error,
+        };
+        if (atomic) aborted = true;
+        return failure;
+      } catch (error) {
+        if (isIdempotencyInfrastructureError(error)) throw error;
+        const failure: BatchItemResult = {
+          index,
+          ok: false,
+          error: toErrorEnvelope(error),
+        };
+        if (atomic) aborted = true;
+        return failure;
+      }
+    });
+  } catch (error) {
+    if (idempotencyContext && isIdempotencyInfrastructureError(error)) {
+      return indeterminateResult(def.name, payload, error, idempotencyContext);
     }
-  });
+    throw error;
+  }
 
   const succeeded = results.filter((r) => r.ok).length;
   const failed = results.length - succeeded;
@@ -200,9 +258,13 @@ async function runBatch(
     for (const { item } of createdForRollback) {
       if (!item.ok) continue;
       try {
+        if (idempotencyContext) await markDownstreamAttempt(idempotencyContext);
         await def.rollback(item.data);
         rolledBack++;
-      } catch {
+      } catch (error) {
+        if (idempotencyContext && isIdempotencyInfrastructureError(error)) {
+          return indeterminateResult(def.name, payload, error, idempotencyContext);
+        }
         // best-effort: swallow rollback errors so we still return the original failure
       }
     }
@@ -215,14 +277,41 @@ async function runBatch(
     ...(rolledBack !== undefined ? { rolled_back: rolledBack } : {}),
   };
 
-  if (idempotencyKey) {
-    store(buildKey(def.name, idempotencyKey), batchResult);
+  if (!idempotencyContext) return batchResult;
+  try {
+    const receipt = await completeIdempotentRequest(idempotencyContext, batchResult);
+    return attachIdempotencyReceipt(batchResult, receipt);
+  } catch (error) {
+    return indeterminateResult(def.name, payload, error, idempotencyContext);
   }
-
-  return batchResult;
 }
 
-export const BATCH_ENVELOPE_HELP = `Batch mode: pass { items: [...], atomic?: boolean, idempotency_key?: string, concurrency?: 1-10 }. Each item is validated independently; failures are reported per-item. atomic:true forces serial execution (concurrency=1) and triggers best-effort rollback of created entities on first failure; subsequent items are skipped with code:"aborted".`;
+function indeterminateResult(
+  operation: string,
+  payload: unknown,
+  error: unknown,
+  context?: Partial<IdempotencyContext>
+): IdempotencyFailure {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code: unknown }).code)
+      : "idempotency_indeterminate";
+  const reason = error instanceof Error ? error.message : "idempotency infrastructure failure";
+  const receipt = ephemeralIndeterminateReceipt(operation, payload, reason, context);
+  return attachIdempotencyReceipt(
+    {
+      ok: false,
+      error: {
+        code,
+        message: "The mutation outcome cannot be safely finalized in the durable idempotency ledger.",
+        fix: "Do not retry automatically. Reconcile authoritative Notion state before using a new explicitly authorized key.",
+      },
+    },
+    receipt
+  );
+}
+
+export const BATCH_ENVELOPE_HELP = `Batch mode: pass { items: [...], atomic?: boolean, idempotency_key?: string, concurrency?: 1-10 }. Each item is validated independently; failures are reported per-item. atomic:true forces serial execution (concurrency=1) and triggers best-effort rollback of created entities on first failure. idempotency_key durably binds the operation and canonical payload, deduplicates identical replays, rejects conflicting reuse, and blocks pending or indeterminate automatic replay.`;
 
 export const _internal = { isBatchPayload };
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,7 +35,7 @@ const EXECUTE_INPUT = {
   payload: z
     .record(z.string(), z.unknown())
     .describe(
-      "Operation parameters. Pass either single-op fields directly, or { items: [...], atomic?, idempotency_key?, concurrency? } for batch."
+      "Operation parameters. Pass either single-op fields directly, or { items: [...], atomic?, idempotency_key?, concurrency? } for batch. Keyed batches use durable idempotency receipts."
     ),
 };
 
@@ -50,6 +50,8 @@ Two ways to call:
   • Batch:  { operation: "set_page_title", payload: { items: [{page_id, title}, ...], atomic?: false, idempotency_key?: "...", concurrency?: 3 } }
 
 If the payload is malformed, the error response includes the full schema + a working example so you can correct and retry in one round-trip. Call notion_describe(operation) ahead of time only for complex shapes (query_database filters, batch_mixed_blocks).
+
+For a batch items[] mutation, idempotency_key is durably bound to the operation and canonical payload fingerprint. Identical replay does not invoke the downstream handler again; conflicting key reuse and pending or indeterminate replay fail closed. The response includes an additive idempotency_receipt. Single-operation payloads are not idempotency-protected.
 
 Most responses are slimmed by default. Pass verbose:true inside payload (single) or per-item (batch) to get the raw Notion SDK response.`;
 

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -146,8 +146,10 @@ describe("dispatch — batch", () => {
       items: [{ value: 200 }],
       idempotency_key: key,
     });
-    // Same cached result is returned and no new side effects ran.
-    expect(second).toEqual(first);
+    expect((first as any).idempotency_receipt.decision).toBe("accepted");
+    expect((second as any).idempotency_receipt.decision).toBe("deduplicated");
+    expect((second as any).summary).toEqual((first as any).summary);
+    expect((second as any).results[0].data.value).toBe(200);
     expect(tracker.created.length).toBe(createdAfterFirst);
   });
 });

--- a/tests/idempotency.test.ts
+++ b/tests/idempotency.test.ts
@@ -1,0 +1,136 @@
+import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  beginIdempotentRequest,
+  completeIdempotentRequest,
+  markDownstreamAttempt,
+} from "../src/dispatch/idempotency.js";
+
+const cleanup: string[] = [];
+
+async function useFreshLedger(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "notion-idempotency-"));
+  cleanup.push(directory);
+  const path = join(directory, "ledger.json");
+  process.env.NOTION_IDEMPOTENCY_STATE_PATH = path;
+  return path;
+}
+
+afterEach(async () => {
+  delete process.env.NOTION_IDEMPOTENCY_STATE_PATH;
+  await Promise.all(cleanup.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("durable idempotency", () => {
+  it("deduplicates identical replay, rejects conflicts, and persists no content", async () => {
+    const path = await useFreshLedger();
+    const key = "customer-visible-retry-key";
+    const payload = {
+      items: [{ page_id: "11111111-1111-4111-8111-111111111111", title: "Private title" }],
+      idempotency_key: key,
+    };
+
+    const admitted = await beginIdempotentRequest("set_page_title", payload, key);
+    expect(admitted.action).toBe("accepted");
+    if (admitted.action !== "accepted") throw new Error("request was not accepted");
+
+    await markDownstreamAttempt(admitted.context);
+    const accepted = await completeIdempotentRequest(admitted.context, {
+      ok: true,
+      summary: { total: 1, succeeded: 1, failed: 0 },
+      results: [
+        {
+          index: 0,
+          ok: true,
+          data: {
+            page_id: "11111111-1111-4111-8111-111111111111",
+            title: "Private title",
+            token: "ntn_must_not_persist",
+          },
+        },
+      ],
+    });
+    expect(accepted.decision).toBe("accepted");
+    expect(accepted.downstream_write_count).toBe(1);
+
+    const replay = await beginIdempotentRequest("set_page_title", payload, key);
+    expect(replay.action).toBe("deduplicated");
+    if (replay.action !== "deduplicated") throw new Error("request was not deduplicated");
+    expect(replay.receipt.submitted_attempt_count).toBe(2);
+    expect(JSON.stringify(replay.stored_result)).toContain("11111111-1111-4111-8111-111111111111");
+
+    const conflict = await beginIdempotentRequest(
+      "set_page_title",
+      { ...payload, items: [{ ...payload.items[0], title: "Different title" }] },
+      key
+    );
+    expect(conflict.action).toBe("rejected");
+    if (conflict.action !== "rejected") throw new Error("conflict was not rejected");
+    expect(conflict.error.code).toBe("idempotency_conflict");
+
+    const durable = await readFile(path, "utf8");
+    expect(durable).not.toContain(key);
+    expect(durable).not.toContain("Private title");
+    expect(durable).not.toContain("Different title");
+    expect(durable).not.toContain("ntn_must_not_persist");
+  });
+
+  it("blocks replay while a prior attempt is pending", async () => {
+    await useFreshLedger();
+    const payload = { items: [{ value: 1 }], idempotency_key: "pending-key" };
+    const first = await beginIdempotentRequest("set_page_title", payload, "pending-key");
+    expect(first.action).toBe("accepted");
+
+    const replay = await beginIdempotentRequest("set_page_title", payload, "pending-key");
+    expect(replay.action).toBe("indeterminate");
+    if (replay.action !== "indeterminate") throw new Error("pending replay was not blocked");
+    expect(replay.error.code).toBe("idempotency_indeterminate");
+  });
+
+  it("recovers a valid temporary ledger when the canonical file is corrupt", async () => {
+    const path = await useFreshLedger();
+    const payload = { items: [{ value: 1 }], idempotency_key: "recovery-key" };
+    const first = await beginIdempotentRequest("set_page_title", payload, "recovery-key");
+    expect(first.action).toBe("accepted");
+
+    await copyFile(path, `${path}.tmp`);
+    await writeFile(path, "{broken", "utf8");
+    const replay = await beginIdempotentRequest("set_page_title", payload, "recovery-key");
+    expect(replay.action).toBe("indeterminate");
+    expect(JSON.parse(await readFile(path, "utf8")).version).toBe(1);
+  });
+
+  it("recovers a dead-process lock", async () => {
+    const path = await useFreshLedger();
+    await writeFile(`${path}.lock`, "99999999", "utf8");
+
+    const admitted = await beginIdempotentRequest(
+      "set_page_title",
+      { items: [{ value: 1 }], idempotency_key: "lock-key" },
+      "lock-key"
+    );
+    expect(admitted.action).toBe("accepted");
+  });
+
+  it("continues processing after a rejected ledger mutation", async () => {
+    const path = await useFreshLedger();
+    await writeFile(path, "{broken", "utf8");
+    await expect(
+      beginIdempotentRequest(
+        "set_page_title",
+        { items: [{ value: 1 }], idempotency_key: "broken-key" },
+        "broken-key"
+      )
+    ).rejects.toMatchObject({ code: "idempotency_ledger_corrupt" });
+
+    await rm(path, { force: true });
+    const admitted = await beginIdempotentRequest(
+      "set_page_title",
+      { items: [{ value: 1 }], idempotency_key: "recovered-key" },
+      "recovered-key"
+    );
+    expect(admitted.action).toBe("accepted");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,19 @@
 // Default the rate limiter to a very high cap during the test suite. Tests
 // that exercise the limiter itself reconfigure it explicitly via
 // configureRateLimiter(); everything else runs without artificial throttling.
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll } from "vitest";
 import { configureRateLimiter } from "../src/dispatch/rate-limit.js";
 
 process.env.NOTION_RATE_LIMIT = process.env.NOTION_RATE_LIMIT ?? "10000";
+const testLedger = join(tmpdir(), `notion-mcp-server-tests-${process.pid}.json`);
+process.env.NOTION_IDEMPOTENCY_STATE_PATH ??= testLedger;
 configureRateLimiter();
+
+afterAll(() => {
+  for (const suffix of ["", ".tmp", ".lock"]) {
+    rmSync(`${testLedger}${suffix}`, { force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- replace the five-minute in-memory idempotency cache with a durable, atomic, lock-protected ledger
- bind each key to a canonical operation and payload fingerprint, deduplicate exact retries, reject conflicting reuse, and block uncertain pending replays
- return an inline idempotency receipt from `notion_execute` while preserving the existing two-tool MCP surface
- sanitize persisted results so raw idempotency keys, request payloads, titles, URLs, tokens, and other sensitive text are not written to the ledger

## Why

The previous cache was lost on restart and matched only the key and operation. A retry after a process restart could therefore repeat a write, while reuse of the same key with a different payload was not detected.

The new ledger defaults to a 30-day TTL and 2,048 completed entries. Its location, TTL, and completed-entry limit can be configured with `NOTION_IDEMPOTENCY_STATE_PATH`, `NOTION_IDEMPOTENCY_TTL_MS`, and `NOTION_IDEMPOTENCY_MAX_ENTRIES`.

## Validation

- `npm run build`
- `npm test` — 25 test files, 282 tests passed
- `npm audit --omit=dev --audit-level=high` — passed after a lockfile-only dependency refresh
- `git diff --check`
- alternate-port restart check using the built MCP server:
  - first listener PID `63052`: request accepted
  - restarted listener PID `24552`: same receipt returned as deduplicated
  - submitted attempts: 2
  - downstream writes: 0
  - ledger persisted across the restart
  - advertised tools remained exactly `notion_execute` and `notion_describe`

The restart check used an intentionally invalid batch item, so it exercised dispatch and durable replay handling without making a Notion API write.
