### PR TITLE
fix(files): resolve symlinks before the NOTION_UPLOAD_ROOT check; CI installs from the lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,19 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Ensure npm supports the release-age cooldown
-        # min-release-age in .npmrc is silently ignored by npm < 11.10.0.
-        run: npm install -g npm@latest
-
       - name: Install dependencies
+        # `npm ci` (not `npm install`): install exactly what package-lock.json
+        # says. `npm install` re-resolves and rewrites the lock in place, so CI
+        # was testing a tree that could differ from the reviewed lockfile — and
+        # a Dependabot bump could be silently undone by the resolver before a
+        # single test ran.
+        #
         # --ignore-scripts blocks dependency lifecycle scripts, the primary npm
         # malware vector. Nothing legitimate in our tree needs install scripts.
-        run: npm install --ignore-scripts --no-audit --no-fund
+        #
+        # No npm upgrade step here any more: min-release-age in .npmrc gates
+        # resolution, and `npm ci` does not resolve.
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Audit production dependencies
         # Fail the build on a high/critical advisory in a shipped (runtime) dep.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`NOTION_UPLOAD_ROOT` no longer escapable through a symlink.** The confinement check compared lexically resolved paths, and `path.resolve` never touches the filesystem — so a symlink sitting inside the root and pointing outside it passed the prefix check, and `readFile` then followed it and uploaded the outside file. Both sides of the comparison are now resolved with `fs.realpath` before the prefix test, so the check sees where the path actually lands. A symlink that stays inside the root still works; a path that does not exist yet still fails with a plain `ENOENT` rather than a confinement error. Only affects setups that set `NOTION_UPLOAD_ROOT` — behavior with it unset is unchanged.
+
+### Added
+
+- **`NOTION_UPLOAD_ROOT` is documented.** It shipped in 2.12.0 without a README entry; it now appears in the environment-variable table.
+
+### Changed
+
+- **CI installs from the lockfile.** The `Install dependencies` step now runs `npm ci` instead of `npm install`. `npm install` re-resolves the dependency graph and rewrites `package-lock.json` in place, so CI could test a tree that differed from the reviewed lockfile, and a Dependabot pin could be undone by the resolver before a single test ran. The separate `npm install -g npm@latest` step is gone with it: `min-release-age` in `.npmrc` gates resolution, and `npm ci` does not resolve.
+
 ## [2.12.0] — 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Official reference: [PAT guide](https://developers.notion.com/guides/get-started
 | `NOTION_READ_ONLY` | — | — | `true`/`1`/`yes` disables every write operation in one switch |
 | `NOTION_ALLOWED_OPERATIONS` | — | all | Comma-separated allowlist of operations or group presets — see [Restricting operations](#restricting-operations) |
 | `NOTION_BLOCKED_OPERATIONS` | — | — | Comma-separated blocklist (same vocabulary); wins over the allowlist |
+| `NOTION_UPLOAD_ROOT` | — | — | Confine `upload_file`'s `path` source to one directory. Unset, a `path` source can read any file the server process can — set this if a model composes the path. Relative paths resolve inside it; symlinks are resolved before the check, so they can't point out |
 | `HTTPS_PROXY` / `HTTP_PROXY` | — | — | Route Notion API traffic through an HTTP(S) proxy (standard env vars, lowercase also accepted) |
 | `NOTION_DAILY_LOG_PAGE_ID` | — | — | Only used by the daily-log MCP prompt |
 

--- a/src/operations/files.ts
+++ b/src/operations/files.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { getClient } from "../services/notion.js";
 import { register } from "./registry.js";
 import { tryHandler } from "../utils/handler.js";
@@ -49,6 +49,32 @@ function expandHome(p: string): string {
 }
 
 /**
+ * Resolve symlinks as far down the path as it actually exists, keeping the
+ * rest lexically.
+ *
+ * realpath() throws ENOENT the moment a segment is missing, but a segment that
+ * does not exist cannot be a symlink either — so the unresolved tail is safe to
+ * re-append. That keeps a missing file an ordinary ENOENT from readFile instead
+ * of turning it into a confinement error.
+ */
+async function realpathAsDeepAsPossible(p: string): Promise<string> {
+  const tail: string[] = [];
+  let current = p;
+  for (;;) {
+    try {
+      const real = await realpath(current);
+      return tail.length > 0 ? join(real, ...tail) : real;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      const parent = dirname(current);
+      if (parent === current) return p; // walked up to the filesystem root
+      tail.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
  * Confine a path source to NOTION_UPLOAD_ROOT when it is set.
  *
  * A path source hands the server a filename and the server reads it, so
@@ -58,12 +84,15 @@ function expandHome(p: string): string {
  *
  * Unset means no confinement, which is the behavior before this existed.
  */
-function resolveUploadPath(p: string): string {
+async function resolveUploadPath(p: string): Promise<string> {
   const root = process.env.NOTION_UPLOAD_ROOT;
   if (!root) return expandHome(p);
 
-  const base = resolve(expandHome(root));
-  const target = resolve(base, expandHome(p));
+  // Compare real paths, not lexical ones. resolve() never touches the disk, so
+  // on its own it green-lights a symlink that sits inside the root and points
+  // out of it: the prefix matches, and then open() follows the link anyway.
+  const base = await realpathAsDeepAsPossible(resolve(expandHome(root)));
+  const target = await realpathAsDeepAsPossible(resolve(base, expandHome(p)));
   const withSep = base.endsWith(sep) ? base : base + sep;
   if (target !== base && !target.startsWith(withSep)) {
     throw new Error(
@@ -84,7 +113,7 @@ async function resolveBytes(source: Source): Promise<Uint8Array<ArrayBuffer>> {
     return out;
   }
   if (source.type === "path") {
-    const buf = await readFile(resolveUploadPath(source.path));
+    const buf = await readFile(await resolveUploadPath(source.path));
     const out = new Uint8Array(buf.byteLength);
     out.set(buf);
     return out;
@@ -225,7 +254,9 @@ register({
     // derive, so filename stays required there.
     const effectiveFilename =
       filename ??
-      (source.type === "path" ? basename(resolveUploadPath(source.path)) : undefined);
+      (source.type === "path"
+        ? basename(await resolveUploadPath(source.path))
+        : undefined);
     if (!effectiveFilename) {
       return {
         ok: false,

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -600,5 +600,51 @@ describe("upload_file (upload root)", () => {
       source: { type: "path", path: join(outside, "outside.txt") },
     });
     assertOk(res);
+  });
+
+  // A prefix check on the lexical path is not confinement: resolve() never
+  // touches the filesystem, so a symlink sitting inside the root passes the
+  // check and then open() follows it straight out of the root.
+  it("refuses a symlink inside the root that points outside it", async () => {
+    process.env.NOTION_UPLOAD_ROOT = root;
+    symlinkSync(join(outside, "outside.txt"), join(root, "escape.txt"));
+    const res = await dispatch("upload_file", {
+      source: { type: "path", path: "escape.txt" },
+    });
+    assertErr(res);
+    expect(res.error.message).toContain("outside NOTION_UPLOAD_ROOT");
+    expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a symlinked directory inside the root that points outside it", async () => {
+    process.env.NOTION_UPLOAD_ROOT = root;
+    symlinkSync(outside, join(root, "escape-dir"));
+    const res = await dispatch("upload_file", {
+      source: { type: "path", path: "escape-dir/outside.txt" },
+    });
+    assertErr(res);
+    expect(res.error.message).toContain("outside NOTION_UPLOAD_ROOT");
+    expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
+  });
+
+  it("still follows a symlink that stays inside the root", async () => {
+    process.env.NOTION_UPLOAD_ROOT = root;
+    symlinkSync(join(root, "inside.txt"), join(root, "link-inside.txt"));
+    const res = await dispatch("upload_file", {
+      source: { type: "path", path: "link-inside.txt" },
+    });
+    assertOk(res);
+  });
+
+  // A path that does not exist cannot be a symlink, so the confinement check
+  // must fall through to a plain ENOENT rather than a resolution error.
+  it("reports a missing in-root file as a normal fs error", async () => {
+    process.env.NOTION_UPLOAD_ROOT = root;
+    const res = await dispatch("upload_file", {
+      source: { type: "path", path: "nope.txt" },
+    });
+    assertErr(res);
+    expect(res.error.message).not.toContain("outside NOTION_UPLOAD_ROOT");
+    expect(notionStub.fileUploads.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Two fixes that came out of reviewing the last batch of community PRs.

## 1. `NOTION_UPLOAD_ROOT` was escapable through a symlink

`resolveUploadPath` confined a `path` source by resolving it and checking the string prefix against the root. `path.resolve` is purely lexical — it never touches the filesystem — so a symlink sitting **inside** the root and pointing **outside** it passed the check, and `readFile` then followed it and uploaded the outside file. This shipped in 2.12.0 (#51).

Confirmed against `main` before the fix — both of these returned `ok: true` and uploaded the out-of-root file:

```
× refuses a symlink inside the root that points outside it
    Expected error result, got: {"ok":true,"data":{...,"filename":"inside.txt"}}
× refuses a symlinked directory inside the root that points outside it
    Expected error result, got: {"ok":true,"data":{...,"filename":"inside.txt"}}
```

Both sides of the comparison now go through `fs.realpath` before the prefix test.

`realpath` throws `ENOENT` as soon as a segment is missing, which would turn "file isn't there" into a confusing confinement error. So `realpathAsDeepAsPossible` resolves as far down as the path actually exists and re-appends the unresolved tail — a segment that doesn't exist can't be a symlink, so keeping it lexical is safe.

Behavior:

- **Unset `NOTION_UPLOAD_ROOT` (the default): nothing changes at all** — the function returns early before any `realpath`.
- A symlink that stays inside the root still resolves and uploads.
- A missing in-root file still fails with a plain `ENOENT`, not a confinement error.
- One small change with the root set: when `filename` is omitted for a symlinked `path` source, the derived basename is now the link target's name rather than the link's.

Residual TOCTOU: a local attacker who can swap a path component between the `realpath` and the `open` can still win the race. Closing that fully needs per-segment `O_NOFOLLOW`, which is out of proportion to the threat here — the realistic case is a symlink already sitting in the root, and that is now handled.

Four tests added, covering symlinked file, symlinked directory, in-root symlink (must still work), and missing file (must stay `ENOENT`).

## 2. CI installed with `npm install` instead of `npm ci`

`npm install` re-resolves the dependency graph and rewrites `package-lock.json` in place, so CI could test a tree that differed from the reviewed lockfile. `npm ci` installs exactly what the lock says. Verified `npm ci` succeeds against the current lock — it has the Linux optional native deps (`@rolldown/binding-linux-*`, `lightningcss-linux-*`, `@emnapi/core`), which is the case the equivalent comment in `publish-npm.yml` warns about.

The `npm install -g npm@latest` step goes away with it: its stated purpose was making `.npmrc`'s `min-release-age` effective, and `.npmrc` already documents that the cooldown "has no effect on `npm ci`" because the lockfile is authoritative.

**This does not clear the open `@hono/node-server` advisory, and I was wrong about why earlier.** The lockfile resolves `@hono/node-server` to `1.19.14`; #58's lock diff only widened the SDK's declared range (`^1.19.9` → `^1.19.9 || ^2.0.5`) and left the resolved version alone, despite the PR title. So it was never pinned at 2.0.12 for `npm install` to undo. Moving it to 2.x is a transitive major bump and belongs in its own PR. The advisory is moderate (below the `--audit-level=high` gate) and unreachable — `serve-static` is not used anywhere in `src/`.

## Also

`NOTION_UPLOAD_ROOT` shipped in 2.12.0 with no README entry. Added a row to the environment-variable table — a confinement control nobody knows about isn't one.

## Verification

```
npm run build    clean
npm test         24 files, 290 passed (was 286; +4 new)
package-lock.json untouched
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)