### PR TITLE
ci: install from the lockfile in the release workflows too

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -22,8 +22,9 @@ jobs:
           node-version: "24"
 
       - name: Install dependencies
-        # Same supply-chain posture as publish-npm.yml: no lifecycle scripts.
-        run: npm install --ignore-scripts --no-audit --no-fund
+        # Same supply-chain posture as publish-npm.yml: install exactly what the
+        # lockfile pins, and no lifecycle scripts.
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Build
         run: npm run build

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,24 +23,30 @@ jobs:
           node-version: "24" # ships with npm >= 11.5 (required for Trusted Publishing)
           registry-url: "https://registry.npmjs.org"
 
-      - name: Ensure npm supports the release-age cooldown
-        # min-release-age in .npmrc is silently ignored by npm < 11.10.0. setup-node
-        # may ship an older npm, which would let `npm install` below pull a
-        # freshly-published (possibly poisoned) version that a dev machine running
-        # current npm would refuse. Upgrade so the cooldown is actually enforced.
+      - name: Ensure npm is current
+        # Kept (unlike in ci.yml) because publishing has its own reason to be on
+        # a current npm: Trusted Publishing / OIDC provenance. node-version 24 is
+        # already meant to satisfy that floor; this guarantees it. A broken
+        # release costs far more than the 15s.
         run: npm install -g npm@latest
 
       - name: Install dependencies
+        # `npm ci` (not `npm install`): the published tarball must be built and
+        # tested against exactly the reviewed lockfile. `npm install` re-resolves
+        # the graph and rewrites the lock in place, so what we shipped was built
+        # from a tree nobody reviewed.
+        #
+        # The previous comment here said npm 11+ strict mode rejected the
+        # lockfile for missing Linux-only optional native deps. That is no longer
+        # true — the committed lock carries them (@rolldown/binding-linux-*,
+        # lightningcss-linux-*, @emnapi/core), and `npm ci` resolves it on
+        # ubuntu-latest in CI.
+        #
         # --ignore-scripts blocks dependency lifecycle scripts (pre/post-install),
         # the primary npm malware vector (Shai-Hulud, TrapDoor). Our runtime deps
         # have no native build step, so nothing legitimate needs them here; our own
         # build runs explicitly via `npm publish` -> `prepare` below.
-        #
-        # 'npm install' (not 'npm ci') because npm 11+ strict mode rejects the
-        # macOS-generated lockfile for missing Linux-only optional native deps
-        # (e.g. @emnapi/core via @rolldown/binding-wasm32-wasi). Lockfile is still
-        # respected — just non-strictly — and the .npmrc cooldown gates resolution.
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **CI installs from the lockfile.** The `Install dependencies` step now runs `npm ci` instead of `npm install`. `npm install` re-resolves the dependency graph and rewrites `package-lock.json` in place, so CI could test a tree that differed from the reviewed lockfile, and a Dependabot pin could be undone by the resolver before a single test ran. The separate `npm install -g npm@latest` step is gone with it: `min-release-age` in `.npmrc` gates resolution, and `npm ci` does not resolve.
+- **Every workflow installs from the lockfile.** `ci.yml`, `publish-npm.yml` and `publish-mcpb.yml` now run `npm ci` instead of `npm install`. `npm install` re-resolves the dependency graph and rewrites `package-lock.json` in place, so CI could test — and the release workflows could build and publish — a tree that differed from the reviewed lockfile, and a Dependabot pin could be undone by the resolver before a single test ran. `publish-npm.yml`'s note that `npm ci` rejected the lockfile over missing Linux-only optional native deps is stale: the committed lock carries them. In `ci.yml` the separate `npm install -g npm@latest` step is gone with it (`min-release-age` in `.npmrc` gates resolution, and `npm ci` does not resolve); `publish-npm.yml` keeps it for Trusted Publishing / OIDC provenance.
 
 ## [2.12.0] — 2026-07-10
 


### PR DESCRIPTION
Follow-up to #61, which switched `ci.yml` to `npm ci`. The two release workflows were still on `npm install`.

## Why this one matters more than #61 did

`npm install` re-resolves the dependency graph and rewrites `package-lock.json` in place. In `ci.yml` that meant tests ran against a tree that could differ from the reviewed lockfile. In `publish-npm.yml` and `publish-mcpb.yml` it means **the npm tarball and the `.mcpb` artifact were built from a tree nobody reviewed** — the drift ships.

## The comment justifying `npm install` was stale

`publish-npm.yml` carried this:

> `npm install` (not `npm ci`) because npm 11+ strict mode rejects the macOS-generated lockfile for missing Linux-only optional native deps (e.g. `@emnapi/core` via `@rolldown/binding-wasm32-wasi`).

That was true of a macOS-generated lock. The committed lock is no longer one — it carries the Linux entries:

```
@rolldown/binding-linux-{arm-gnueabihf,arm64-gnu,arm64-musl,ppc64-gnu,s390x-gnu,x64-gnu,x64-musl}
lightningcss-linux-{arm-gnueabihf,arm64-gnu,arm64-musl,x64-gnu,x64-musl}
@emnapi/{core,runtime,wasi-threads}
```

and `npm ci` resolved it on `ubuntu-latest` in run [30746334299](https://github.com/awkoy/notion-mcp-server/actions/runs/30746334299) — 260 packages, 5s, no strict-mode error.

Worth keeping in mind: this is exactly the failure mode the old comment describes, so it can come back if someone regenerates the lock on macOS. `npm ci` failing loudly in CI is the right way to find that out — `npm install` was papering over it.

## `npm install -g npm@latest` stays here (it went away in ci.yml)

Not an inconsistency. In `ci.yml` its only stated purpose was making `.npmrc`'s `min-release-age` effective, and `.npmrc` itself documents the cooldown has no effect under `npm ci`. Publishing has an independent reason to be on a current npm — Trusted Publishing / OIDC provenance — and the asymmetry in cost decides it: if removing it in CI were wrong, CI goes red and I fix it; if removing it in the release pipeline were wrong, a release breaks.

## Verification

These workflows only fire on a `v*` tag, so CI cannot exercise them, and triggering them by hand would either publish to npm or cut a GitHub release. Instead I rehearsed both paths locally in a clean detached worktree, running exactly what each workflow runs:

```
npm ci --ignore-scripts --no-audit --no-fund   261 packages, package-lock.json untouched
npm audit --omit=dev --audit-level=high        exit 0

publish-npm.yml path:
  npm test                                     24 files, 290 passed
  npm pack --dry-run                           notion-mcp-server-2.12.0.tgz, 57 files, 77.5 kB
                                               (prepare -> build ran)

publish-mcpb.yml path:
  npm run build                                clean
  node scripts/build-mcpb.mjs                  dist/notion-mcp-server.mcpb, 4.7 MB
```

All four workflow files re-parse as valid YAML; the only remaining `npm install` anywhere is the intentional global `npm install -g npm@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)