### PR TITLE
fix: allow null values in database property schema for property deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -294,9 +294,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,9 +311,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -334,9 +328,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -354,9 +345,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -374,9 +362,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -394,9 +379,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,9 +2262,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2304,9 +2283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2328,9 +2304,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2352,9 +2325,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/schema/database.ts
+++ b/src/schema/database.ts
@@ -315,6 +315,7 @@ export const VERIFICATION_DB_PROPERTY_SCHEMA = z.object({
 });
 
 // Combined database property schema
+// Allows null for property deletion (Notion API: set property to null to delete it)
 export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
   preprocessJson,
   z
@@ -342,6 +343,7 @@ export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
       UNIQUE_ID_DB_PROPERTY_SCHEMA,
       VERIFICATION_DB_PROPERTY_SCHEMA,
     ])
-    .describe("Union of all possible database property types")
+    .nullable()
+    .describe("Union of all possible database property types. Set to null to delete.")
 );
 


### PR DESCRIPTION
## Summary

This fix adds  to the  in .

## Problem

The Notion API supports deleting database properties by setting them to null:
```
PATCH /v1/databases/{database_id}
{
  properties: {
    ColumnName: null
  }
}
```

However, the Zod schema validation was rejecting null values because  requires a  field.

## Solution

Add  to the  so that null values pass validation and are forwarded to the Notion API.

## Impact

- Enables deleting properties via  operation
- No breaking changes - existing valid inputs still work
- Null values are now properly forwarded to the Notion API

## Testing

Verified that:
1. Setting a property to null deletes it from the database schema
2. Existing property updates still work correctly