### PR TITLE
test: validate every operation example against its schema

### DIFF
--- a/src/operations/data-sources.ts
+++ b/src/operations/data-sources.ts
@@ -132,7 +132,11 @@ register({
   example: {
     data_source_id: "<data-source-id>",
     properties: {
-      Status: { type: "status", status: { options: [] } },
+      // The API cannot create `status` property schemas; use select/multi_select.
+      Priority: {
+        type: "select",
+        select: { options: [{ name: "High", color: "red" }, { name: "Low", color: "gray" }] },
+      },
     },
   },
   handler: tryHandler(async ({ data_source_id, title, properties, icon, archived, in_trash, verbose }) => {

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { initOperations, listOperations } from "../src/operations/index.js";
+
+// `notion_describe` hands `example` / `exampleBatch` to the model as the
+// canonical call shape. An example that fails its own schema teaches the
+// model a call that the server then rejects, so every one of them must parse.
+
+beforeAll(async () => {
+  await initOperations();
+});
+
+function issues(op: { name: string; schema: { safeParse: (v: unknown) => any } }, value: unknown, label: string): string[] {
+  const r = op.schema.safeParse(value);
+  if (r.success) return [];
+  return [
+    `${op.name} ${label}: ` +
+      r.error.issues.map((i: { path: PropertyKey[]; message: string }) => `${i.path.join(".") || "<root>"} ${i.message}`).join("; "),
+  ];
+}
+
+describe("operation examples", () => {
+  it("every example validates against its operation schema", () => {
+    const failures = listOperations().flatMap((op) => issues(op, op.example, "example"));
+    expect(failures).toEqual([]);
+  });
+
+  it("every exampleBatch item validates against its operation schema", () => {
+    const failures = listOperations().flatMap((op) => {
+      const batch = op.exampleBatch as { items?: unknown[] } | undefined;
+      if (!batch) return [];
+      expect(op.batchable, `${op.name} has exampleBatch but is not batchable`).toBe(true);
+      expect(Array.isArray(batch.items), `${op.name} exampleBatch.items must be an array`).toBe(true);
+      return (batch.items ?? []).flatMap((item, i) => issues(op, item, `exampleBatch.items[${i}]`));
+    });
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/examples.test.ts`: every registered operation's `example`, and every item in `exampleBatch.items`, must `safeParse` against the operation's own schema. `notion_describe` hands these to the model as the canonical call shape, so an example that fails its schema teaches a call the server then rejects.
- Fixes the one failure it found: `update_data_source`'s example used `type: "status"`, which `DATABASE_PROPERTY_SCHEMA` rejects (the Notion API cannot create `status` property schemas). Now uses a `select` property.

Surfaced while reviewing #53.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 27 files / 314 tests pass