### PR TITLE
fix(data-sources): accept null in update_data_source properties to delete a property

### DIFF
--- a/src/operations/data-sources.ts
+++ b/src/operations/data-sources.ts
@@ -96,7 +96,20 @@ register({
 const UpdateDataSourceParams = z.object({
   data_source_id: z.string(),
   title: z.array(z.unknown()).optional().describe("Rich text array for the data source title."),
-  properties: z.record(z.string(), DATABASE_PROPERTY_SCHEMA).optional(),
+  // dataSources.update is the one endpoint where a property may be null: that
+  // deletes the property. create_database's initial_data_source has no such
+  // form, so the nullable lives here rather than on DATABASE_PROPERTY_SCHEMA.
+  properties: z
+    .record(
+      z.string(),
+      DATABASE_PROPERTY_SCHEMA.nullable().describe(
+        "A property definition, or null to delete the property."
+      )
+    )
+    .optional()
+    .describe(
+      "Map of property name → definition. Set a property to null to delete it from the data source, together with its values on every page."
+    ),
   icon: z.unknown().optional(),
   in_trash: z
     .boolean()

--- a/src/operations/databases.ts
+++ b/src/operations/databases.ts
@@ -336,10 +336,12 @@ const UpdateDatabaseParams = z.object({
   title: z.string().optional(),
   title_rich: z.array(TEXT_RICH_TEXT_ITEM_REQUEST_SCHEMA).optional(),
   description: z.array(TEXT_RICH_TEXT_ITEM_REQUEST_SCHEMA).optional(),
+  // Nullable so a `{ Name: null }` delete attempt reaches the properties_moved
+  // redirect below instead of dying in validation with no pointer.
   properties: z
-    .record(z.string(), DATABASE_PROPERTY_SCHEMA)
+    .record(z.string(), DATABASE_PROPERTY_SCHEMA.nullable())
     .optional()
-    .describe("Deprecated on the 2025-09-03 surface — properties live on the data source. Call update_data_source instead. Rejected here so the migration is explicit."),
+    .describe("Deprecated on the 2025-09-03 surface — properties live on the data source. Call update_data_source instead (there, null deletes a property). Rejected here so the migration is explicit."),
   is_inline: z.boolean().optional(),
   is_locked: z.boolean().optional(),
   in_trash: z

--- a/src/schema/database.ts
+++ b/src/schema/database.ts
@@ -315,6 +315,7 @@ export const VERIFICATION_DB_PROPERTY_SCHEMA = z.object({
 });
 
 // Combined database property schema
+// Allows null for property deletion (Notion API: set property to null to delete it)
 export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
   preprocessJson,
   z
@@ -342,6 +343,7 @@ export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
       UNIQUE_ID_DB_PROPERTY_SCHEMA,
       VERIFICATION_DB_PROPERTY_SCHEMA,
     ])
-    .describe("Union of all possible database property types")
+    .nullable()
+    .describe("Union of all possible database property types. Set to null to delete.")
 );
 

--- a/src/schema/database.ts
+++ b/src/schema/database.ts
@@ -314,8 +314,10 @@ export const VERIFICATION_DB_PROPERTY_SCHEMA = z.object({
   description: z.string().optional(),
 });
 
-// Combined database property schema
-// Allows null for property deletion (Notion API: set property to null to delete it)
+// Combined database property schema. This is a property *definition* only:
+// the null-deletes-the-property form Notion takes on dataSources.update is
+// added at update_data_source, because create_database (initial_data_source)
+// has no such form and update_database no longer carries properties at all.
 export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
   preprocessJson,
   z
@@ -343,7 +345,6 @@ export const DATABASE_PROPERTY_SCHEMA = z.preprocess(
       UNIQUE_ID_DB_PROPERTY_SCHEMA,
       VERIFICATION_DB_PROPERTY_SCHEMA,
     ])
-    .nullable()
-    .describe("Union of all possible database property types. Set to null to delete.")
+    .describe("Union of all possible database property types")
 );
 

--- a/tests/property-delete.test.ts
+++ b/tests/property-delete.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+const notionStub = {
+  databases: { create: vi.fn(), update: vi.fn() },
+  dataSources: { update: vi.fn() },
+};
+
+vi.mock("../src/services/notion.js", () => ({
+  getClient: async () => notionStub,
+}));
+
+import { initOperations, getOperation } from "../src/operations/index.js";
+import { dispatch } from "../src/dispatch/index.js";
+import { emitJsonSchema } from "../src/schema/emit.js";
+import { preprocessJson } from "../src/schema/preprocess.js";
+
+beforeAll(async () => {
+  await initOperations();
+});
+
+beforeEach(() => {
+  for (const group of Object.values(notionStub)) {
+    for (const fn of Object.values(group)) fn.mockReset();
+  }
+  notionStub.dataSources.update.mockResolvedValue({ id: "ds-1", properties: {} });
+  notionStub.databases.update.mockResolvedValue({ id: "db-1", title: [], properties: {} });
+});
+
+// Notion deletes a data source property when its definition is null:
+//   PATCH /data_sources/:id { properties: { "Old": null } }
+// That is the only place the API takes null for a property, so the schema,
+// the emitted JSON Schema, and the handler all have to let it through here
+// and nowhere else.
+describe("update_data_source: null deletes a property", () => {
+  it("parses null as a property value and keeps it as null", () => {
+    const schema = getOperation("update_data_source")!.schema;
+    const res = schema.safeParse({
+      data_source_id: "ds-1",
+      properties: { Old: null, Kept: { type: "rich_text", rich_text: {} } },
+    });
+    expect(res.success).toBe(true);
+    const props = (res.data as { properties: Record<string, unknown> }).properties;
+    expect(props.Old).toBeNull();
+    expect(props.Kept).toMatchObject({ type: "rich_text" });
+  });
+
+  it("preprocessJson leaves null alone rather than turning it into something else", () => {
+    expect(preprocessJson(null)).toBeNull();
+  });
+
+  it("advertises null in the emitted JSON Schema and says what it does", () => {
+    const json = emitJsonSchema(getOperation("update_data_source")!.schema) as any;
+    const properties = json.properties.properties;
+    expect(properties.description).toMatch(/null/i);
+    expect(properties.description).toMatch(/delete/i);
+
+    const value = properties.additionalProperties;
+    expect(value.description).toMatch(/null/i);
+    expect(value.description).toMatch(/delete/i);
+    const variants: unknown[] = value.anyOf ?? value.oneOf;
+    expect(variants).toContainEqual({ type: "null" });
+    // The definition union is still there next to it, not replaced by it.
+    const definition = variants.find((v) => v && typeof v === "object" && !("type" in (v as object)));
+    expect(definition).toBeDefined();
+    expect((definition as any).oneOf ?? (definition as any).anyOf).toBeInstanceOf(Array);
+  });
+
+  it("forwards the null to dataSources.update untouched", async () => {
+    const res = await dispatch("update_data_source", {
+      data_source_id: "ds-1",
+      properties: { Old: null, Kept: { type: "rich_text", rich_text: {} } },
+    });
+    expect((res as { ok: boolean }).ok).toBe(true);
+
+    const body = notionStub.dataSources.update.mock.calls[0][0] as {
+      properties: Record<string, unknown>;
+    };
+    expect(Object.hasOwn(body.properties, "Old")).toBe(true);
+    expect(body.properties.Old).toBeNull();
+    expect(body.properties.Kept).toMatchObject({ type: "rich_text" });
+    // What the SDK serializes is what Notion reads.
+    expect(JSON.parse(JSON.stringify(body)).properties).toEqual({
+      Old: null,
+      Kept: { type: "rich_text", rich_text: {} },
+    });
+  });
+});
+
+describe("null property elsewhere", () => {
+  it("update_database redirects a null delete attempt to update_data_source", async () => {
+    const res = await dispatch("update_database", {
+      database_id: "db-1",
+      properties: { Old: null },
+    });
+    expect((res as { ok: boolean }).ok).toBe(false);
+    const err = (res as { error: { code: string; fix: string } }).error;
+    expect(err.code).toBe("properties_moved");
+    expect(err.fix).toContain("update_data_source");
+    expect(notionStub.databases.update).not.toHaveBeenCalled();
+  });
+
+  it("create_database does not take null: there is nothing to delete yet", async () => {
+    const res = await dispatch("create_database", {
+      parent: { type: "page_id", page_id: "p-1" },
+      title: "T",
+      properties: { Old: null },
+    });
+    expect((res as { ok: boolean }).ok).toBe(false);
+    expect((res as { error: { code: string } }).error.code).toBe("validation_error");
+    expect(notionStub.databases.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Supersedes #72 by @FrancoMeneses — his commit is carried here as-is (authorship preserved); the only thing dropped from it is the unrelated `package-lock.json` churn (removed `libc` fields).

## Problem

Notion deletes a property from a data source when its definition is `null`:

```json
PATCH /data_sources/:id  { "properties": { "Old": null } }
```

`DATABASE_PROPERTY_SCHEMA` is a discriminated union of property *definitions*, so a `null` value died in validation before reaching the API, and the emitted JSON Schema never told the model that `null` is an option.

## Where null support ended up, and why

#72 put `.nullable()` on `DATABASE_PROPERTY_SCHEMA` itself. That schema is shared by three call sites, and only one of them takes `null` on the 2025-09-03 surface (checked against `@notionhq/client` 5.26.0 types):

| operation | SDK type | accepts `null`? |
|---|---|---|
| `update_data_source` | `UpdateDataSourceBodyParameters.properties: Record<string, (...definition) \| { name } \| null>` | yes — deletes the property |
| `create_database` | `InitialDataSourceRequest.properties: Record<string, PropertyConfigurationRequest>` | no (nothing to delete yet) |
| `update_database` | `UpdateDatabaseBodyParameters` has no `properties` at all | n/a — already rejected here with `properties_moved` |

So the second commit moves the nullable to the one place it is real:

- `src/operations/data-sources.ts` — `update_data_source.properties` is `z.record(z.string(), DATABASE_PROPERTY_SCHEMA.nullable().describe("A property definition, or null to delete the property."))`, and the record description says that null deletes the property together with its values on every page. The handler forwards `properties` untouched, so the `null` reaches `dataSources.update`.
- `src/operations/databases.ts` — `update_database.properties` also takes `null`, only so a `{ Old: null }` delete attempt lands on the existing `properties_moved` redirect ("call update_data_source") instead of a validation error with no pointer. `create_database` keeps the non-null record.
- `src/schema/database.ts` — back to the definition-only union; the comment explains where the null form lives.

## Verified end to end

- `preprocessJson(null)` passes `null` through; `.nullable()` on the preprocess pipe short-circuits it.
- `notion_describe` for `update_data_source` now emits `properties.additionalProperties.anyOf: [ { oneOf: [ ...22 property arms ] }, { type: "null" } ]` with the "null deletes" description on both the record and the value.
- Nothing in `dispatch` / `tryHandler` strips nulls; the SDK body serializes to `{ "Old": null, ... }`.

## Tests

`tests/property-delete.test.ts`:

- schema parses `{ Old: null, Kept: {...} }` and keeps the `null`
- emitted JSON Schema advertises `{ type: "null" }` next to the definition union and describes it as delete
- `dataSources.update` receives the `null` untouched
- `update_database` with `{ Old: null }` → `properties_moved` pointing at `update_data_source`, no SDK call
- `create_database` with `{ Old: null }` → `validation_error`, no SDK call
